### PR TITLE
fix crashes

### DIFF
--- a/src/vllm_tgis_adapter/grpc/grpc_server.py
+++ b/src/vllm_tgis_adapter/grpc/grpc_server.py
@@ -262,7 +262,10 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
         for i in range(len(responses)):
             res = responses[i]
             response = self._convert_output(
-                res.outputs[0], resp_options, max_is_token_limit[i], time_limit_reached
+                res.outputs[0],
+                resp_options,
+                max_is_token_limit=max_is_token_limit[i],
+                time_limit_reached=time_limit_reached,
             )
             response = self._convert_input_details(
                 res, resp_options, sampling_params, response

--- a/src/vllm_tgis_adapter/tgis_utils/metrics.py
+++ b/src/vllm_tgis_adapter/tgis_utils/metrics.py
@@ -90,6 +90,8 @@ class ServiceMetrics:
         self.tgi_request_input_count.inc(num_requests)
 
     def observe_queue_time(self, engine_output: RequestOutput) -> None:
+        assert engine_output.metrics
+
         self.tgi_request_queue_duration.observe(engine_output.metrics.time_in_queue)
 
     def count_request_failure(self, reason: FailureReasonLabel) -> None:


### PR DESCRIPTION
- fix _convert_output usage:
  ```console
  ERROR 06-20 15:57:54 grpc_server.py:123] Generate failed
  ERROR 06-20 15:57:54 grpc_server.py:123] Traceback (most recent call last):
  ERROR 06-20 15:57:54 grpc_server.py:123]   File "/opt/vllm/lib64/python3.11/site-packages/vllm_tgis_adapter/grpc/grpc_server.py", line 140, in func_with_log
  ERROR 06-20 15:57:54 grpc_server.py:123]     return await func(*args, **kwargs)
  ERROR 06-20 15:57:54 grpc_server.py:123]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ERROR 06-20 15:57:54 grpc_server.py:123]   File "/opt/vllm/lib64/python3.11/site-packages/vllm_tgis_adapter/grpc/grpc_server.py", line 264, in Generate
  ERROR 06-20 15:57:54 grpc_server.py:123]     response = self._convert_output(
  ERROR 06-20 15:57:54 grpc_server.py:123]                ^^^^^^^^^^^^^^^^^^^^^
  ERROR 06-20 15:57:54 grpc_server.py:123] TypeError: TextGenerationService._convert_output() takes 3 positional arguments but 5 were given
  ```
- fix mypy errors
