### PR TITLE
gha: test multiple versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -79,9 +79,3 @@ jobs:
 
       - name: Build package
         run: nox -s build-${{ matrix.pyv }}
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: vllm-tgis-wheel
-          path: dist/vllm_tgis_adapter*.whl

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,6 +11,11 @@ on:
 
 env:
   FORCE_COLOR: "1"
+  # facilitate testing by building vLLM for CPU when needed
+  VLLM_CPU_DISABLE_AVX512: "true"
+  VLLM_TARGET_DEVICE: "cpu"
+  # prefer torch cpu version
+  PIP_EXTRA_INDEX_URL: "https://download.pytorch.org/whl/cpu"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -25,6 +30,11 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         pyv: ["3.11"]
+        vllm_version:
+          # - "pypi" # skip the pypi version as it will not work with CPU
+          - "git+https://github.com/vllm-project/vllm@v0.5.0.post1"
+          - "git+https://github.com/vllm-project/vllm@main"
+          - "git+https://github.com/opendatahub-io/vllm@main"
 
     steps:
       - name: Check out the repository
@@ -49,6 +59,14 @@ jobs:
           python -m pip install --upgrade pip nox
           pip --version
           nox --version
+
+      - name: Set custom vllm version
+        if: ${{ matrix.vllm_version != 'pypi' }}
+        run: |
+          vllm_version="vllm@${{matrix.vllm_version}}"
+          echo "Using vllm@${vllm_version}"
+
+          sed -i "s|\"vllm.*\",|\"${vllm_version}\",|g" pyproject.toml
 
       - name: Lint code and check dependencies
         run: nox -s lint-${{ matrix.pyv }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -76,6 +76,10 @@ jobs:
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Build package
         run: nox -s build-${{ matrix.pyv }}

--- a/README.md
+++ b/README.md
@@ -78,3 +78,17 @@ nox -s tests-3.10 # run tests session for a specific python version
 nox -s build-3.11 # build the wheel package
 nox -s lint-3.11 -- --mypy # run linting with type checks
 ```
+
+### Testing without a GPU
+
+The standard vllm built requires an Nvidia GPU. When this is not available, it is possible to compile `vllm` from source with CPU support:
+
+```bash
+
+env \
+    VLLM_CPU_DISABLE_AVX512=true VLLM_TARGET_DEVICE=cpu \
+    PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu \
+    pip install git+https://github.com/vllm-project/vllm
+```
+
+making it possible to run the tests on most hardware. Please note that the `pip` extra index url is required in order to install the torch CPU version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,8 @@ select = ["ALL"]
 ]
 "src/vllm_tgis_adapter/healthcheck.py" = ["T201"]
 "src/vllm_tgis_adapter/_version.py" = ["ALL"]
-"tests/**" = ["S", "ARG001", "ARG002", "ANN"]
+"tests/**" = ["S", "ARG001", "ARG002", "ANN", "PT019", "FBT001", "FBT002"]
+"tests/utils.py" = ["T201"]
 "setup.py" = [
   "T201",  # print() use
   "S603",  # subprocess call: check for execution of untrusted input

--- a/src/vllm_tgis_adapter/grpc/grpc_server.py
+++ b/src/vllm_tgis_adapter/grpc/grpc_server.py
@@ -844,7 +844,10 @@ async def start_grpc_server(
     assert isinstance(engine, AsyncLLMEngine)
     assert isinstance(engine.engine, _AsyncLLMEngine)
 
-    logger.info(memory_summary(engine.engine.device_config.device))
+    if (device_type := engine.engine.device_config.device.type) == "cuda":
+        logger.info(memory_summary(engine.engine.device_config.device))
+    else:
+        logger.warning("Cannot print device usage for device type: %s", device_type)
 
     server = aio.server()
 

--- a/src/vllm_tgis_adapter/grpc/grpc_server.py
+++ b/src/vllm_tgis_adapter/grpc/grpc_server.py
@@ -922,21 +922,15 @@ async def run_grpc_server(
     *,
     disable_log_stats: bool,
 ) -> None:
-    async def _force_log() -> None:
-        while True:
-            await asyncio.sleep(10)
-            await engine.do_log_stats()
-
-    if not disable_log_stats:
-        asyncio.create_task(_force_log())  # noqa: RUF006
-
     assert args is not None
 
     server = await start_grpc_server(engine, args)
 
     try:
         while True:
-            await asyncio.sleep(60)
+            await asyncio.sleep(10)
+            if not disable_log_stats:
+                await engine.do_log_stats()
     except asyncio.CancelledError:
         print("Gracefully stopping gRPC server")  # noqa: T201
         await server.stop(30)  # TODO configurable grace

--- a/src/vllm_tgis_adapter/grpc/grpc_server.py
+++ b/src/vllm_tgis_adapter/grpc/grpc_server.py
@@ -191,16 +191,22 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
         assert self.tokenizer is not None
 
         # Swap in the special TGIS stats logger
-        assert hasattr(self.engine.engine, "stat_logger")
-        assert self.engine.engine.stat_logger
-
-        vllm_stat_logger = self.engine.engine.stat_logger
-        tgis_stats_logger = TGISStatLogger(
-            vllm_stat_logger=vllm_stat_logger,
-            max_sequence_len=self.config.max_model_len,
-        )
-        # 🌶️🌶️🌶️ sneaky sneak
-        self.engine.engine.stat_logger = tgis_stats_logger
+        if hasattr(self.engine.engine, "stat_logger"):
+            # vllm <=0.5.1
+            tgis_stats_logger = TGISStatLogger(
+                vllm_stat_logger=self.engine.engine.stat_logger,
+                max_sequence_len=self.config.max_model_len,
+            )
+            self.engine.engine.stat_logger = tgis_stats_logger
+        elif hasattr(self.engine.engine, "stat_loggers"):
+            # vllm>=0.5.2
+            tgis_stats_logger = TGISStatLogger(
+                vllm_stat_logger=self.engine.engine.stat_loggers["prometheus"],
+                max_sequence_len=self.config.max_model_len,
+            )
+            self.engine.engine.stat_loggers["prometheus"] = tgis_stats_logger
+        else:
+            raise ValueError("engine doesn't have any known loggers.")
 
         self.health_servicer.set(
             self.SERVICE_NAME,

--- a/src/vllm_tgis_adapter/tgis_utils/metrics.py
+++ b/src/vllm_tgis_adapter/tgis_utils/metrics.py
@@ -5,7 +5,13 @@ from enum import StrEnum, auto
 
 from prometheus_client import Counter, Gauge, Histogram
 from vllm import RequestOutput
-from vllm.engine.metrics import StatLogger, Stats
+from vllm.engine.metrics import Stats
+
+try:
+    from vllm.engine.metrics import StatLoggerBase
+except ImportError:
+    # vllm<=0.5.1
+    from vllm.engine.metrics import StatLogger as StatLoggerBase
 
 from vllm_tgis_adapter.grpc.pb.generation_pb2 import (
     BatchedTokenizeRequest,
@@ -102,10 +108,10 @@ class ServiceMetrics:
         self.tgi_request_duration.observe(duration)
 
 
-class TGISStatLogger(StatLogger):
+class TGISStatLogger(StatLoggerBase):
     """Wraps the vLLM StatLogger to report TGIS metric names for compatibility."""
 
-    def __init__(self, vllm_stat_logger: StatLogger, max_sequence_len: int):
+    def __init__(self, vllm_stat_logger: StatLoggerBase, max_sequence_len: int):
         # Not calling super-init because we're wrapping and delegating to
         # vllm_stat_logger
         self._vllm_stat_logger = vllm_stat_logger

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 
 @pytest.fixture()
 def args(monkeypatch, grpc_server_thread_port, http_server_thread_port):
+    """Return parsed CLI arguments for the adapter/vLLM."""
     # avoid parsing pytest arguments as vllm/vllm_tgis_adapter arguments
     monkeypatch.setattr(
         sys,
@@ -49,9 +50,14 @@ def args(monkeypatch, grpc_server_thread_port, http_server_thread_port):
 
 
 @pytest.fixture()
-def engine(args) -> AsyncLLMEngine:
-    """Return a vLLM engine from the args."""
-    engine_args = AsyncEngineArgs.from_cli_args(args)
+def engine_args(args) -> AsyncEngineArgs:
+    """Return AsyncEngineArgs from cli args."""
+    return AsyncEngineArgs.from_cli_args(args)
+
+
+@pytest.fixture()
+def engine(engine_args) -> AsyncLLMEngine:
+    """Return a vLLM engine from the engine args."""
     engine = AsyncLLMEngine.from_engine_args(
         engine_args,  # type: ignore[arg-type]
         usage_context=UsageContext.OPENAI_API_SERVER,
@@ -122,7 +128,7 @@ def http_server_url(http_server_thread_port):
 
 
 @pytest.fixture()
-def _http_server(engine, model_config, args, http_server_url):
+def _http_server(engine, model_config, engine_args, args, http_server_url):
     """Spins up the http server in a background thread."""
 
     def _health_check() -> None:

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -1,6 +1,50 @@
 import pytest
 
+from .utils import GrpcClient
 
-@pytest.mark.usefixtures("_grpc_server")
-def test_startup():
-    """Test that the grpc_server fixture starts up properly."""
+
+@pytest.fixture()
+def grpc_client(grpc_server_thread_port, _grpc_server):
+    """Return a grpc client connected to the grpc server."""
+    with GrpcClient(
+        host="localhost",
+        port=grpc_server_thread_port,
+        insecure=True,
+    ) as client:
+        yield client
+
+
+def test_generation_request(grpc_client, grpc_server_thread_port):
+    response = grpc_client.make_request(
+        "The answer to life the universe and everything is "
+    )
+
+    assert response.text
+    assert response.generated_token_count
+    assert response.stop_reason is not None
+
+
+def test_generation_request_stream(grpc_client, grpc_server_thread_port):
+    streaming_response = grpc_client.make_request_stream(
+        "The answer to life the universe and everything is ",
+    )
+
+    text_chunks: list[str] = [chunk.text for chunk in streaming_response]
+
+    assert text_chunks
+    assert len(text_chunks) == 11
+    assert "".join(text_chunks)
+
+
+def test_batched_generation_request(grpc_client, grpc_server_thread_port):
+    responses = list(
+        grpc_client.make_request(
+            [
+                "The answer to life the universe and everything is ",
+                "Medicinal herbs ",
+            ],
+        )
+    )
+
+    assert len(responses) == 2
+    assert all(response.text for response in responses)

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -1,9 +1,29 @@
-import pytest
 import requests
 
 
-@pytest.mark.usefixtures("_http_server")
-def test_startup(http_server_url):
+def test_startup(http_server_url, _http_server):
     """Test that the http_server fixture starts up properly."""
     requests.get(f"{http_server_url}/health").raise_for_status()
-    # requests.get(f"{http_server_url}/v1/models").raise_for_status()
+
+
+def test_completions(http_server_url, _http_server):
+    response = requests.get(f"{http_server_url}/v1/models")
+    response.raise_for_status()
+
+    data = response.json()["data"]
+    model_id = data[0]["id"]
+
+    response = requests.post(
+        f"{http_server_url}/v1/completions",
+        json={
+            "prompt": "The answer tho life the universe and everything is ",
+            "model": model_id,
+        },
+    )
+    response.raise_for_status()
+
+    completion = response.json()
+
+    generated_text = completion["choices"][0]["text"]
+
+    assert generated_text

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,31 @@
+from __future__ import annotations
+
 import socket
+import ssl
+import sys
 import time
 from contextlib import closing
-from typing import Callable, TypeVar
+from typing import TYPE_CHECKING, Callable, TypeVar
+
+import grpc
+
+from vllm_tgis_adapter.grpc.pb.generation_pb2 import (
+    BatchedGenerationRequest,
+    GenerationRequest,
+    ModelInfoRequest,
+    Parameters,
+    SingleGenerationRequest,
+    StoppingCriteria,
+)
+from vllm_tgis_adapter.grpc.pb.generation_pb2_grpc import GenerationServiceStub
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Sequence
+
+    from vllm_tgis_adapter.grpc.pb.generation_pb2 import (
+        GenerationResponse,
+        ModelInfoResponse,
+    )
 
 _T = TypeVar("_T")
 
@@ -32,3 +56,204 @@ def wait_until(
         time.sleep(pause)
 
     raise TimeoutError("timed out waiting") from exc
+
+
+def get_server_certificate(host: str, port: int) -> str:
+    """Connect to host:port and get the certificate it presents.
+
+    This is almost the same as `ssl.get_server_certificate`, but
+    when opening the TLS socket, `server_hostname` is also provided.
+
+    This retrieves the correct certificate for hosts using name-based
+    virtual hosting.
+    """
+    if sys.version_info >= (3, 10):
+        # ssl.get_server_certificate supports TLS SNI only above 3.10
+        # https://github.com/python/cpython/pull/16820
+        return ssl.get_server_certificate((host, port))
+
+    context = ssl.SSLContext()
+
+    with (
+        socket.create_connection((host, port)) as sock,
+        context.wrap_socket(sock, server_hostname=host) as ssock,
+    ):
+        cert_der = ssock.getpeercert(binary_form=True)
+
+    assert cert_der
+    return ssl.DER_cert_to_PEM_cert(cert_der)
+
+
+class GrpcClient:
+    def __init__(  # noqa: PLR0913
+        self,
+        host: str,
+        port: int,
+        *,
+        insecure: bool = False,
+        verify: bool | None = None,
+        ca_cert: bytes | str | None = None,
+        client_cert: bytes | str | None = None,
+        client_key: bytes | str | None = None,
+    ) -> None:
+        self._channel = self._make_channel(
+            host,
+            port,
+            insecure=insecure,
+            verify=verify,
+            client_key=client_key,
+            client_cert=client_cert,
+            ca_cert=ca_cert,
+        )
+        self.generation_service_stub = GenerationServiceStub(channel=self._channel)
+
+    def model_info(self, model_id: str) -> ModelInfoResponse:
+        return self.generation_service_stub.ModelInfo(
+            request=ModelInfoRequest(model_id=model_id),
+        )
+
+    def make_request(
+        self,
+        text: str | list[str],
+        model_id: str | None = None,
+        max_new_tokens: int = 10,
+    ) -> GenerationResponse | Sequence[GenerationResponse]:
+        if single_request := isinstance(text, str):
+            text = [text]
+
+        request = BatchedGenerationRequest(
+            model_id=model_id,
+            requests=[GenerationRequest(text=piece) for piece in text],
+            params=Parameters(
+                stopping=StoppingCriteria(max_new_tokens=max_new_tokens),
+            ),
+        )
+
+        response = self.generation_service_stub.Generate(
+            request=request,
+        )
+
+        if single_request:
+            return response.responses[0]
+
+        return response.responses
+
+    def make_request_stream(
+        self,
+        text: str,
+        model_id: str | None = None,
+        max_new_tokens: int = 10,
+    ) -> Generator[GenerationResponse, None, None]:
+        request = SingleGenerationRequest(
+            model_id=model_id,
+            request=GenerationRequest(text=text),
+            params=Parameters(
+                stopping=StoppingCriteria(max_new_tokens=max_new_tokens),
+            ),
+        )
+
+        try:
+            yield from self.generation_service_stub.GenerateStream(request=request)
+        except grpc._channel._MultiThreadedRendezvous as exc:  # noqa: SLF001
+            raise RuntimeError(exc.details()) from exc
+
+    def __enter__(self):  # noqa: D105
+        return self
+
+    def __exit__(self, *exc_info):  # noqa: D105
+        self._close()
+        return False
+
+    def _close(self):
+        try:
+            if hasattr(self, "_channel") and self._channel:
+                self._channel.close()
+        except Exception as exc:  # noqa: BLE001
+            print(f"Unexpected exception while closing client: {exc}")
+
+    def __del__(self):  # noqa: D105
+        self._close()
+
+    def _make_channel(  # noqa: D417,PLR0913
+        self,
+        host: str,
+        port: int,
+        *,
+        insecure: bool = False,
+        verify: bool | None = None,
+        ca_cert: bytes | str | None = None,
+        client_key: bytes | str | None = None,
+        client_cert: bytes | str | None = None,
+    ) -> grpc.Channel:
+        """Create a grpc channel.
+
+        Args:
+        ----
+        - host: str
+        - port: str
+        - (optional) insecure: use a plaintext connection (default=False)
+        - (optional) verify: set to False to disable remote host certificate(s)
+                     verification. Cannot be used with `plaintext` or with MTLS
+        - (optional) ca_cert: certificate authority to use
+        - (optional) client_key: client key for mTLS mode
+        - (optional) client_cert: client cert for mTLS mode
+
+        """
+        if not host.strip():
+            raise ValueError("A non empty host name is required")
+        if int(port) <= 0:
+            raise ValueError("A non zero port number is required")
+        if insecure and any(
+            (val is not None) for val in (ca_cert, client_key, client_cert)
+        ):
+            raise ValueError("cannot use insecure with TLS/mTLS certificates")
+        if insecure and verify:
+            raise ValueError("insecure cannot be used with verify")
+
+        connection = f"{host}:{port}"
+        if insecure:
+            print("Connecting over an insecure plaintext grpc channel")
+            return grpc.insecure_channel(connection)
+
+        client_key_bytes = self._try_load_certificate(client_key)
+        client_cert_bytes = self._try_load_certificate(client_cert)
+        ca_cert_bytes = self._try_load_certificate(ca_cert)
+
+        credentials_kwargs: dict[str, bytes] = {}
+        if ca_cert_bytes and not (any((client_cert_bytes, client_key_bytes))):
+            print("Connecting using provided CA certificate for secure channel")
+            credentials_kwargs.update(root_certificates=ca_cert_bytes)
+        elif client_cert_bytes and client_key_bytes and ca_cert_bytes:
+            print("Connecting using mTLS for secure channel")
+            credentials_kwargs.update(
+                root_certificates=ca_cert_bytes,
+                private_key=client_key_bytes,
+                certificate_chain=client_cert_bytes,
+            )
+        elif verify is False:
+            print(
+                f"insecure mode: trusting remote certificate from {host}:{port}",
+            )
+
+            cert = get_server_certificate(host, port).encode()
+            credentials_kwargs.update(root_certificates=cert)
+
+        return grpc.secure_channel(
+            connection, grpc.ssl_channel_credentials(**credentials_kwargs)
+        )
+
+    @staticmethod
+    def _try_load_certificate(certificate: bytes | str | None) -> bytes | None:
+        """Return contents if the certificate points to a file, return the bytes otherwise."""  # noqa: E501
+        if not certificate:
+            return None
+
+        if isinstance(certificate, bytes):
+            return certificate
+
+        if isinstance(certificate, str):
+            with open(certificate, "rb") as secret_file:
+                return secret_file.read()
+        raise ValueError(
+            f"{certificate=} should be a path to a certificate files or bytes"
+        )


### PR DESCRIPTION
- gha: test multiple vLLM versions
- tests: use real vLLM version (stop using mocks)
- grpc_server: only print memory summary for CUDA devices
- tests: add real tests (for both grpc and http server)
- enable code coverage


The reason for this:
1. We can test multiple vLLM version and catch any issues before they hit PyPi
2. We can test a real vLLM engine by using the CPU executor

