### PR TITLE
feat: Add model-util CLI 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ tests = [
 ]
 dev = [
   "vllm_tgis_adapter[tests]",
-  "ruff==0.5.4",
+  "ruff==0.5.5",
   "mypy==1.10.1",
   "types-protobuf==5.26.0.20240422",
   "types-requests==2.32.0.20240712"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ Source = "https://github.com/opendatahub-io/vllm_tgis_adapter"
 
 [project.scripts]
 grpc-healthcheck = "vllm_tgis_adapter.healthcheck:cli"
-vllm = "vllm_tgis_adapter.tgis_utils.scripts:cli"
+adapter = "vllm_tgis_adapter.tgis_utils.scripts:cli"
 
 [project.optional-dependencies]
 tests = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,9 @@ vllm_tgis_adapter = [
 
 [tool.pytest.ini_options]
 addopts = "-ra"
+markers = [
+  "large"
+]
 
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ Source = "https://github.com/opendatahub-io/vllm-tgis-adapter"
 [project.scripts]
 grpc-healthcheck = "vllm_tgis_adapter.healthcheck:cli"
 model-util = "vllm_tgis_adapter.tgis_utils.scripts:cli"
+text-generation-server = "vllm_tgis_adapter.tgis_utils.scripts:cli"
 
 [project.optional-dependencies]
 tests = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ Source = "https://github.com/opendatahub-io/vllm-tgis-adapter"
 
 [project.scripts]
 grpc-healthcheck = "vllm_tgis_adapter.healthcheck:cli"
-adapter = "vllm_tgis_adapter.tgis_utils.scripts:cli"
+model-util = "vllm_tgis_adapter.tgis_utils.scripts:cli"
 
 [project.optional-dependencies]
 tests = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,9 +84,9 @@ vllm_tgis_adapter = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "-ra"
+addopts = "-ra -k \"not hf_data\""
 markers = [
-  "large"
+  "hf_data: marks tests that download data from HF hub (deselect with '-m \"not hf_data\"')"
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ Issues = "https://github.com/opendatahub-io/vllm-tgis-adapter/issues"
 Source = "https://github.com/opendatahub-io/vllm-tgis-adapter"
 
 [project.scripts]
-grpc-healthcheck = "vllm_tgis_adapter.healthcheck:cli"
+grpc_healthcheck = "vllm_tgis_adapter.healthcheck:cli"
 model-util = "vllm_tgis_adapter.tgis_utils.scripts:cli"
 text-generation-server = "vllm_tgis_adapter.tgis_utils.scripts:cli"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,8 @@ Issues = "https://github.com/opendatahub-io/vllm_tgis_adapter/issues"
 Source = "https://github.com/opendatahub-io/vllm_tgis_adapter"
 
 [project.scripts]
-grpc_healthcheck = "vllm_tgis_adapter.healthcheck:cli"
+grpc-healthcheck = "vllm_tgis_adapter.healthcheck:cli"
+vllm = "vllm_tgis_adapter.tgis_utils.scripts:cli"
 
 [project.optional-dependencies]
 tests = [

--- a/src/vllm_tgis_adapter/__main__.py
+++ b/src/vllm_tgis_adapter/__main__.py
@@ -323,19 +323,6 @@ if __name__ == "__main__":
     logger.info("args: %s", args)
 
     engine_args = AsyncEngineArgs.from_cli_args(args)
-
-    if hasattr(engine_args, "image_input_type") and (  # vllm <= 0.5.0.post1
-        engine_args.image_input_type is not None
-        and engine_args.image_input_type.upper() != "PIXEL_VALUES"
-    ):
-        # Enforce pixel values as image input type for vision language models
-        # when serving with API server
-        raise ValueError(
-            f"Invalid image_input_type: {engine_args.image_input_type}. "
-            "Only --image-input-type 'pixel_values' is supported for serving "
-            "vision language models with the vLLM API server."
-        )
-
     engine = AsyncLLMEngine.from_engine_args(
         engine_args,  # type: ignore[arg-type]
         usage_context=UsageContext.OPENAI_API_SERVER,

--- a/src/vllm_tgis_adapter/tgis_utils/hub.py
+++ b/src/vllm_tgis_adapter/tgis_utils/hub.py
@@ -1,0 +1,270 @@
+import concurrent
+import datetime
+import glob
+import json
+import logging
+import os
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import torch
+from huggingface_hub import HfApi, hf_hub_download, try_to_load_from_cache
+from huggingface_hub.utils import LocalEntryNotFoundError
+from safetensors.torch import (_find_shared_tensors, _is_complete, load_file,
+                               save_file)
+from tqdm import tqdm
+
+TRUST_REMOTE_CODE = os.getenv("TRUST_REMOTE_CODE") == "true"
+logger = logging.getLogger(__name__)
+
+
+def weight_hub_files(model_name,
+                     extension=".safetensors",
+                     revision=None,
+                     auth_token=None):
+    """Get the safetensors filenames on the hub"""
+    exts = [extension] if isinstance(extension, str) else extension
+    api = HfApi()
+    info = api.model_info(model_name, revision=revision, token=auth_token)
+    filenames = [
+        s.rfilename for s in info.siblings if any(
+            s.rfilename.endswith(ext) and len(s.rfilename.split("/")) == 1
+            and "arguments" not in s.rfilename and "args" not in s.rfilename
+            and "training" not in s.rfilename for ext in exts)
+    ]
+    return filenames
+
+
+def weight_files(model_name, extension=".safetensors", revision=None):
+    """Get the local safetensors filenames"""
+    filenames = weight_hub_files(model_name, extension)
+    files = []
+    for filename in filenames:
+        cache_file = try_to_load_from_cache(model_name,
+                                            filename=filename,
+                                            revision=revision)
+        if cache_file is None:
+            raise LocalEntryNotFoundError(
+                f"File {filename} of model {model_name} not found in "
+                f"{os.getenv('HUGGINGFACE_HUB_CACHE', 'the local cache')}. "
+                f"Please run `vllm \
+                    download-weights {model_name}` first.")
+        files.append(cache_file)
+
+    return files
+
+
+def download_weights(model_name,
+                     extension=".safetensors",
+                     revision=None,
+                     auth_token=None):
+    """Download the safetensors files from the hub"""
+    filenames = weight_hub_files(model_name,
+                                 extension,
+                                 revision=revision,
+                                 auth_token=auth_token)
+
+    download_function = partial(
+        hf_hub_download,
+        repo_id=model_name,
+        local_files_only=False,
+        revision=revision,
+        token=auth_token,
+    )
+
+    print(f"Downloading {len(filenames)} files for model {model_name}")
+    executor = ThreadPoolExecutor(max_workers=5)
+    futures = [
+        executor.submit(download_function, filename=filename)
+        for filename in filenames
+    ]
+    files = [
+        future.result()
+        for future in tqdm(concurrent.futures.as_completed(futures),
+                           total=len(futures))
+    ]
+
+    return files
+
+
+def get_model_path(model_name: str, revision: Optional[str] = None):
+    """Get path to model dir in local huggingface hub (model) cache"""
+    config_file = "config.json"
+    err = None
+    try:
+        config_path = try_to_load_from_cache(
+            model_name,
+            config_file,
+            cache_dir=os.getenv("TRANSFORMERS_CACHE"
+                                ),  # will fall back to HUGGINGFACE_HUB_CACHE
+            revision=revision,
+        )
+        if config_path is not None:
+            return config_path.removesuffix(f"/{config_file}")
+    except ValueError as e:
+        err = e
+
+    if os.path.isfile(f"{model_name}/{config_file}"):
+        return model_name  # Just treat the model name as an explicit model path
+
+    if err is not None:
+        raise err
+
+    raise ValueError(
+        f"Weights not found in local cache for model {model_name}")
+
+
+def local_weight_files(model_path: str, extension=".safetensors"):
+    """Get the local safetensors filenames"""
+    ext = "" if extension is None else extension
+    return glob.glob(f"{model_path}/*{ext}")
+
+
+def local_index_files(model_path: str, extension=".safetensors"):
+    """Get the local .index.json filename"""
+    ext = "" if extension is None else extension
+    return glob.glob(f"{model_path}/*{ext}.index.json")
+
+
+def _remove_duplicate_names(
+    state_dict: Dict[str, torch.Tensor],
+    *,
+    preferred_names: List[str] = None,
+    discard_names: List[str] = None,
+) -> Dict[str, List[str]]:
+    if preferred_names is None:
+        preferred_names = []
+    preferred_names = set(preferred_names)
+    if discard_names is None:
+        discard_names = []
+    discard_names = set(discard_names)
+
+    shareds = _find_shared_tensors(state_dict)
+    to_remove = defaultdict(list)
+    for shared in shareds:
+        # _find_shared_tensors returns a list of sets of names of tensors that
+        # have the same data, including sets with one element that aren't shared
+        if len(shared) == 1:
+            continue
+
+        complete_names = set(
+            [name for name in shared if _is_complete(state_dict[name])])
+        if not complete_names:
+            raise RuntimeError(f"Error while trying to find names to remove \
+                    to save state dict, but found no suitable name to \
+                        keep for saving amongst: {shared}. None is covering \
+                            the entire storage.Refusing to save/load the model \
+                                since you could be storing much more \
+                                    memory than needed. Please refer to\
+            https://huggingface.co/docs/safetensors/torch_shared_tensors \
+                                            for more information. \
+                                                Or open an issue.")
+
+        keep_name = sorted(list(complete_names))[0]
+
+        # Mechanism to preferentially select keys to keep
+        # coming from the on-disk file to allow
+        # loading models saved with a different choice
+        # of keep_name
+        preferred = complete_names.difference(discard_names)
+        if preferred:
+            keep_name = sorted(list(preferred))[0]
+
+        if preferred_names:
+            preferred = preferred_names.intersection(complete_names)
+            if preferred:
+                keep_name = sorted(list(preferred))[0]
+        for name in sorted(shared):
+            if name != keep_name:
+                to_remove[keep_name].append(name)
+    return to_remove
+
+
+def convert_file(pt_file: Path, sf_file: Path, discard_names: List[str]):
+    """
+    Convert a pytorch file to a safetensors file
+    This will remove duplicate tensors from the file.
+
+    Unfortunately, this might not respect *transformers* convention.
+    Forcing us to check for potentially different keys during load when looking
+    for specific tensors (making tensor sharing explicit).
+    """
+    loaded = torch.load(pt_file, map_location="cpu")
+    if "state_dict" in loaded:
+        loaded = loaded["state_dict"]
+    to_removes = _remove_duplicate_names(loaded, discard_names=discard_names)
+
+    metadata = {"format": "pt"}
+    for kept_name, to_remove_group in to_removes.items():
+        for to_remove in to_remove_group:
+            if to_remove not in metadata:
+                metadata[to_remove] = kept_name
+            del loaded[to_remove]
+    # Force tensors to be contiguous
+    loaded = {k: v.contiguous() for k, v in loaded.items()}
+
+    dirname = os.path.dirname(sf_file)
+    os.makedirs(dirname, exist_ok=True)
+    save_file(loaded, sf_file, metadata=metadata)
+    reloaded = load_file(sf_file)
+    for k in loaded:
+        pt_tensor = loaded[k]
+        sf_tensor = reloaded[k]
+        if not torch.equal(pt_tensor, sf_tensor):
+            raise RuntimeError(f"The output tensors do not match for key {k}")
+
+
+def convert_index_file(source_file: Path, dest_file: Path,
+                       pt_files: List[Path], sf_files: List[Path]):
+    weight_file_map = {s.name: d.name for s, d in zip(pt_files, sf_files)}
+
+    logger.info(
+        "Converting pytorch .bin.index.json files to .safetensors.index.json")
+    with open(source_file, "r") as f:
+        index = json.load(f)
+
+    index["weight_map"] = {
+        k: weight_file_map[v]
+        for k, v in index["weight_map"].items()
+    }
+
+    with open(dest_file, "w") as f:
+        json.dump(index, f, indent=4)
+
+
+def convert_files(pt_files: List[Path],
+                  sf_files: List[Path],
+                  discard_names: List[str] = None):
+    assert len(pt_files) == len(sf_files)
+
+    # Filter non-inference files
+    pairs = [
+        p for p in zip(pt_files, sf_files) if not any(s in p[0].name for s in [
+            "arguments",
+            "args",
+            "training",
+            "optimizer",
+            "scheduler",
+            "index",
+        ])
+    ]
+
+    N = len(pairs)
+
+    if N == 0:
+        logger.warning("No pytorch .bin weight files found to convert")
+        return
+
+    logger.info("Converting %d pytorch .bin files to .safetensors...", N)
+
+    for i, (pt_file, sf_file) in enumerate(pairs):
+        file_count = (i + 1) / N
+        logger.info('Converting: [%d] "$s"', file_count, pt_file.name)
+        start = datetime.datetime.now()
+        convert_file(pt_file, sf_file, discard_names)
+        elapsed = datetime.datetime.now() - start
+        logger.info('Converted: [%d] "%s" -- Took: %d', file_count,
+                    sf_file.name, elapsed)

--- a/src/vllm_tgis_adapter/tgis_utils/hub.py
+++ b/src/vllm_tgis_adapter/tgis_utils/hub.py
@@ -86,7 +86,7 @@ def download_weights(
     )
 
     logger.info("Downloading %s files for model %s", len(filenames), model_name)
-    executor = ThreadPoolExecutor(max_workers=os.cpu_count())
+    executor = ThreadPoolExecutor(max_workers=min(16, os.cpu_count()))
     futures = [
         executor.submit(download_function, filename=filename) for filename in filenames
     ]

--- a/src/vllm_tgis_adapter/tgis_utils/hub.py
+++ b/src/vllm_tgis_adapter/tgis_utils/hub.py
@@ -86,7 +86,7 @@ def download_weights(
     )
 
     logger.info("Downloading %s files for model %s", len(filenames), model_name)
-    executor = ThreadPoolExecutor(max_workers=5)
+    executor = ThreadPoolExecutor(max_workers=os.cpu_count())
     futures = [
         executor.submit(download_function, filename=filename) for filename in filenames
     ]

--- a/src/vllm_tgis_adapter/tgis_utils/hub.py
+++ b/src/vllm_tgis_adapter/tgis_utils/hub.py
@@ -1,71 +1,80 @@
+from __future__ import annotations
+
 import concurrent
 import datetime
-import glob
 import json
 import logging
 import os
-from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from pathlib import Path
-from typing import Dict, List, Optional
 
 import torch
 from huggingface_hub import HfApi, hf_hub_download, try_to_load_from_cache
 from huggingface_hub.utils import LocalEntryNotFoundError
-from safetensors.torch import (_find_shared_tensors, _is_complete, load_file,
-                               save_file)
+from safetensors.torch import _remove_duplicate_names, load_file, save_file
 from tqdm import tqdm
 
-TRUST_REMOTE_CODE = os.getenv("TRUST_REMOTE_CODE") == "true"
 logger = logging.getLogger(__name__)
 
 
-def weight_hub_files(model_name,
-                     extension=".safetensors",
-                     revision=None,
-                     auth_token=None):
-    """Get the safetensors filenames on the hub"""
+def weight_hub_files(
+    model_name: str,
+    extension: str = ".safetensors",
+    revision: str | None = None,
+    auth_token: str | None = None,
+) -> list:
+    """Get the safetensors filenames on the hub."""
     exts = [extension] if isinstance(extension, str) else extension
     api = HfApi()
     info = api.model_info(model_name, revision=revision, token=auth_token)
     filenames = [
-        s.rfilename for s in info.siblings if any(
-            s.rfilename.endswith(ext) and len(s.rfilename.split("/")) == 1
-            and "arguments" not in s.rfilename and "args" not in s.rfilename
-            and "training" not in s.rfilename for ext in exts)
+        s.rfilename
+        for s in info.siblings
+        if any(
+            s.rfilename.endswith(ext)
+            and len(s.rfilename.split("/")) == 1
+            and "arguments" not in s.rfilename
+            and "args" not in s.rfilename
+            and "training" not in s.rfilename
+            for ext in exts
+        )
     ]
     return filenames
 
 
-def weight_files(model_name, extension=".safetensors", revision=None):
-    """Get the local safetensors filenames"""
+def weight_files(
+    model_name: str, extension: str = ".safetensors", revision: str | None = None
+) -> list:
+    """Get the local safetensors filenames."""
     filenames = weight_hub_files(model_name, extension)
     files = []
     for filename in filenames:
-        cache_file = try_to_load_from_cache(model_name,
-                                            filename=filename,
-                                            revision=revision)
+        cache_file = try_to_load_from_cache(
+            model_name, filename=filename, revision=revision
+        )
         if cache_file is None:
             raise LocalEntryNotFoundError(
                 f"File {filename} of model {model_name} not found in "
                 f"{os.getenv('HUGGINGFACE_HUB_CACHE', 'the local cache')}. "
                 f"Please run `vllm \
-                    download-weights {model_name}` first.")
+                    download-weights {model_name}` first."
+            )
         files.append(cache_file)
 
     return files
 
 
-def download_weights(model_name,
-                     extension=".safetensors",
-                     revision=None,
-                     auth_token=None):
-    """Download the safetensors files from the hub"""
-    filenames = weight_hub_files(model_name,
-                                 extension,
-                                 revision=revision,
-                                 auth_token=auth_token)
+def download_weights(
+    model_name: str,
+    extension: str = ".safetensors",
+    revision: str | None = None,
+    auth_token: str | None = None,
+) -> list:
+    """Download the safetensors files from the hub."""
+    filenames = weight_hub_files(
+        model_name, extension, revision=revision, auth_token=auth_token
+    )
 
     download_function = partial(
         hf_hub_download,
@@ -75,31 +84,30 @@ def download_weights(model_name,
         token=auth_token,
     )
 
-    print(f"Downloading {len(filenames)} files for model {model_name}")
+    logger.info("Downloading {len(filenames)} files for model {model_name}")
     executor = ThreadPoolExecutor(max_workers=5)
     futures = [
-        executor.submit(download_function, filename=filename)
-        for filename in filenames
+        executor.submit(download_function, filename=filename) for filename in filenames
     ]
     files = [
         future.result()
-        for future in tqdm(concurrent.futures.as_completed(futures),
-                           total=len(futures))
+        for future in tqdm(concurrent.futures.as_completed(futures), total=len(futures))
     ]
 
     return files
 
 
-def get_model_path(model_name: str, revision: Optional[str] = None):
-    """Get path to model dir in local huggingface hub (model) cache"""
+def get_model_path(model_name: str, revision: str | None = None) -> str:
+    """Get path to model dir in local huggingface hub (model) cache."""
     config_file = "config.json"
     err = None
     try:
         config_path = try_to_load_from_cache(
             model_name,
             config_file,
-            cache_dir=os.getenv("TRANSFORMERS_CACHE"
-                                ),  # will fall back to HUGGINGFACE_HUB_CACHE
+            cache_dir=os.getenv(
+                "TRANSFORMERS_CACHE"
+            ),  # will fall back to HUGGINGFACE_HUB_CACHE
             revision=revision,
         )
         if config_path is not None:
@@ -107,90 +115,33 @@ def get_model_path(model_name: str, revision: Optional[str] = None):
     except ValueError as e:
         err = e
 
-    if os.path.isfile(f"{model_name}/{config_file}"):
+    if Path.isfile(f"{model_name}/{config_file}"):
         return model_name  # Just treat the model name as an explicit model path
 
     if err is not None:
         raise err
 
-    raise ValueError(
-        f"Weights not found in local cache for model {model_name}")
+    raise ValueError(f"Weights not found in local cache for model {model_name}")
 
 
-def local_weight_files(model_path: str, extension=".safetensors"):
-    """Get the local safetensors filenames"""
+def local_weight_files(model_path: str, extension: str = ".safetensors") -> list:
+    """Get the local safetensors filenames."""
     ext = "" if extension is None else extension
-    return glob.glob(f"{model_path}/*{ext}")
+    return Path.glob(f"{model_path}/*{ext}")
 
 
-def local_index_files(model_path: str, extension=".safetensors"):
-    """Get the local .index.json filename"""
+def local_index_files(model_path: str, extension: str = ".safetensors") -> list:
+    """Get the local .index.json filename."""
     ext = "" if extension is None else extension
-    return glob.glob(f"{model_path}/*{ext}.index.json")
+    return Path.glob(f"{model_path}/*{ext}.index.json")
 
 
-def _remove_duplicate_names(
-    state_dict: Dict[str, torch.Tensor],
-    *,
-    preferred_names: List[str] = None,
-    discard_names: List[str] = None,
-) -> Dict[str, List[str]]:
-    if preferred_names is None:
-        preferred_names = []
-    preferred_names = set(preferred_names)
-    if discard_names is None:
-        discard_names = []
-    discard_names = set(discard_names)
+def convert_file(pt_file: Path, sf_file: Path, discard_names: list[str]) -> None:
+    """Convert a pytorch file to a safetensors file.
 
-    shareds = _find_shared_tensors(state_dict)
-    to_remove = defaultdict(list)
-    for shared in shareds:
-        # _find_shared_tensors returns a list of sets of names of tensors that
-        # have the same data, including sets with one element that aren't shared
-        if len(shared) == 1:
-            continue
-
-        complete_names = set(
-            [name for name in shared if _is_complete(state_dict[name])])
-        if not complete_names:
-            raise RuntimeError(f"Error while trying to find names to remove \
-                    to save state dict, but found no suitable name to \
-                        keep for saving amongst: {shared}. None is covering \
-                            the entire storage.Refusing to save/load the model \
-                                since you could be storing much more \
-                                    memory than needed. Please refer to\
-            https://huggingface.co/docs/safetensors/torch_shared_tensors \
-                                            for more information. \
-                                                Or open an issue.")
-
-        keep_name = sorted(list(complete_names))[0]
-
-        # Mechanism to preferentially select keys to keep
-        # coming from the on-disk file to allow
-        # loading models saved with a different choice
-        # of keep_name
-        preferred = complete_names.difference(discard_names)
-        if preferred:
-            keep_name = sorted(list(preferred))[0]
-
-        if preferred_names:
-            preferred = preferred_names.intersection(complete_names)
-            if preferred:
-                keep_name = sorted(list(preferred))[0]
-        for name in sorted(shared):
-            if name != keep_name:
-                to_remove[keep_name].append(name)
-    return to_remove
-
-
-def convert_file(pt_file: Path, sf_file: Path, discard_names: List[str]):
-    """
-    Convert a pytorch file to a safetensors file
-    This will remove duplicate tensors from the file.
-
-    Unfortunately, this might not respect *transformers* convention.
-    Forcing us to check for potentially different keys during load when looking
-    for specific tensors (making tensor sharing explicit).
+    This will remove duplicate tensors from the file. Unfortunately, this might not
+    respect *transformers* convention forcing us to check for potentially different
+    keys during load when looking for specific tensors (making tensor sharing explicit).
     """
     loaded = torch.load(pt_file, map_location="cpu")
     if "state_dict" in loaded:
@@ -206,8 +157,8 @@ def convert_file(pt_file: Path, sf_file: Path, discard_names: List[str]):
     # Force tensors to be contiguous
     loaded = {k: v.contiguous() for k, v in loaded.items()}
 
-    dirname = os.path.dirname(sf_file)
-    os.makedirs(dirname, exist_ok=True)
+    dirname = Path.parent(sf_file)
+    Path(dirname).mkdir(parents=True)
     save_file(loaded, sf_file, metadata=metadata)
     reloaded = load_file(sf_file)
     for k in loaded:
@@ -217,54 +168,59 @@ def convert_file(pt_file: Path, sf_file: Path, discard_names: List[str]):
             raise RuntimeError(f"The output tensors do not match for key {k}")
 
 
-def convert_index_file(source_file: Path, dest_file: Path,
-                       pt_files: List[Path], sf_files: List[Path]):
+def convert_index_file(
+    source_file: Path, dest_file: Path, pt_files: list[Path], sf_files: list[Path]
+) -> None:
     weight_file_map = {s.name: d.name for s, d in zip(pt_files, sf_files)}
 
-    logger.info(
-        "Converting pytorch .bin.index.json files to .safetensors.index.json")
-    with open(source_file, "r") as f:
+    logger.info("Converting pytorch .bin.index.json files to .safetensors.index.json")
+    with open(source_file) as f:
         index = json.load(f)
 
     index["weight_map"] = {
-        k: weight_file_map[v]
-        for k, v in index["weight_map"].items()
+        k: weight_file_map[v] for k, v in index["weight_map"].items()
     }
 
     with open(dest_file, "w") as f:
         json.dump(index, f, indent=4)
 
 
-def convert_files(pt_files: List[Path],
-                  sf_files: List[Path],
-                  discard_names: List[str] = None):
+def convert_files(
+    pt_files: list[Path], sf_files: list[Path], discard_names: list[str] | None = None
+) -> None:
     assert len(pt_files) == len(sf_files)
 
     # Filter non-inference files
     pairs = [
-        p for p in zip(pt_files, sf_files) if not any(s in p[0].name for s in [
-            "arguments",
-            "args",
-            "training",
-            "optimizer",
-            "scheduler",
-            "index",
-        ])
+        p
+        for p in zip(pt_files, sf_files)
+        if not any(
+            s in p[0].name
+            for s in [
+                "arguments",
+                "args",
+                "training",
+                "optimizer",
+                "scheduler",
+                "index",
+            ]
+        )
     ]
 
-    N = len(pairs)
+    n = len(pairs)
 
-    if N == 0:
+    if n == 0:
         logger.warning("No pytorch .bin weight files found to convert")
         return
 
-    logger.info("Converting %d pytorch .bin files to .safetensors...", N)
+    logger.info("Converting %d pytorch .bin files to .safetensors...", n)
 
     for i, (pt_file, sf_file) in enumerate(pairs):
-        file_count = (i + 1) / N
-        logger.info('Converting: [%d] "$s"', file_count, pt_file.name)
-        start = datetime.datetime.now()
+        file_count = (i + 1) / n
+        logger.info('Converting: [%d] "%s"', file_count, pt_file.name)
+        start = datetime.datetime.now(tz=datetime.UTC)
         convert_file(pt_file, sf_file, discard_names)
-        elapsed = datetime.datetime.now() - start
-        logger.info('Converted: [%d] "%s" -- Took: %d', file_count,
-                    sf_file.name, elapsed)
+        elapsed = datetime.datetime.now(tz=datetime.UTC) - start
+        logger.info(
+            'Converted: [%d] "%s" -- Took: %d', file_count, sf_file.name, elapsed
+        )

--- a/src/vllm_tgis_adapter/tgis_utils/hub.py
+++ b/src/vllm_tgis_adapter/tgis_utils/hub.py
@@ -125,13 +125,13 @@ def get_model_path(model_name: str, revision: str | None = None) -> str:
     raise ValueError(f"Weights not found in local cache for model {model_name}")
 
 
-def local_weight_files(model_path: str, extension: str = ".safetensors") -> list:
+def local_weight_files(model_path: str, extension: str = ".safetensors") -> list[Path]:
     """Get the local safetensors filenames."""
     ext = "" if extension is None else extension
     return list(Path(f"{model_path}").glob(f"*{ext}"))
 
 
-def local_index_files(model_path: str, extension: str = ".safetensors") -> list:
+def local_index_files(model_path: str, extension: str = ".safetensors") -> list[Path]:
     """Get the local .index.json filename."""
     ext = "" if extension is None else extension
     return list(Path(f"{model_path}").glob(f"*{ext}.index.json"))
@@ -158,8 +158,7 @@ def convert_file(pt_file: Path, sf_file: Path, discard_names: list[str]) -> None
     # Force tensors to be contiguous
     loaded = {k: v.contiguous() for k, v in loaded.items()}
 
-    dirname = Path(sf_file).parent
-    Path(dirname).mkdir(parents=True, exist_ok=True)
+    sf_file.parent.mkdir(parents=True, exist_ok=True)
     save_file(loaded, sf_file, metadata=metadata)
     reloaded = load_file(sf_file)
     for k in loaded:
@@ -183,7 +182,7 @@ def convert_index_file(
     }
 
     with open(dest_file, "w") as f:
-        json.dump(index, f, indent=4)
+        json.dump(index, f)
 
 
 def convert_files(

--- a/src/vllm_tgis_adapter/tgis_utils/hub.py
+++ b/src/vllm_tgis_adapter/tgis_utils/hub.py
@@ -101,26 +101,18 @@ def download_weights(
 def get_model_path(model_name: str, revision: str | None = None) -> str:
     """Get path to model dir in local huggingface hub (model) cache."""
     config_file = "config.json"
-    err = None
-    try:
-        config_path = try_to_load_from_cache(
-            model_name,
-            config_file,
-            cache_dir=os.getenv(
-                "TRANSFORMERS_CACHE"
-            ),  # will fall back to HUGGINGFACE_HUB_CACHE
-            revision=revision,
-        )
-        if config_path is not None:
-            return config_path.removesuffix(f"/{config_file}")
-    except ValueError as e:
-        err = e
-
+    config_path = try_to_load_from_cache(
+        model_name,
+        config_file,
+        cache_dir=os.getenv(
+            "TRANSFORMERS_CACHE"
+        ),  # will fall back to HUGGINGFACE_HUB_CACHE
+        revision=revision,
+    )
+    if config_path is not None:
+        return config_path.removesuffix(f"/{config_file}")
     if Path(f"{model_name}/{config_file}").is_file():
         return model_name  # Just treat the model name as an explicit model path
-
-    if err is not None:
-        raise err
 
     raise ValueError(f"Weights not found in local cache for model {model_name}")
 

--- a/src/vllm_tgis_adapter/tgis_utils/scripts.py
+++ b/src/vllm_tgis_adapter/tgis_utils/scripts.py
@@ -1,38 +1,50 @@
 # The CLI entrypoint to vLLM.
-import argparse
-import os
-import signal
-import sys
-from pathlib import Path
-from typing import Optional
+from __future__ import annotations
 
+import logging
+from typing import TYPE_CHECKING
+
+import Path
 from vllm.model_executor.model_loader.weight_utils import convert_bin_to_safetensor_file
 from vllm.scripts import registrer_signal_handlers
 from vllm.utils import FlexibleArgumentParser
+
+from vllm_tgis_adapter.tgis_utils import hub
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    import argparse
+
 
 def tgis_cli(args: argparse.Namespace) -> None:
     registrer_signal_handlers()
 
     if args.command == "download-weights":
-        download_weights(args.model_name, args.revision, args.token,
-                         args.extension, args.auto_convert)
+        download_weights(
+            args.model_name,
+            args.revision,
+            args.token,
+            args.extension,
+            args.auto_convert,
+        )
     elif args.command == "convert-to-safetensors":
         convert_bin_to_safetensor_file(args.model_name, args.revision)
     elif args.command == "convert-to-fast-tokenizer":
-        convert_to_fast_tokenizer(args.model_name, args.revision,
-                                  args.output_path)
+        convert_to_fast_tokenizer(args.model_name, args.revision, args.output_path)
 
 
 def download_weights(
     model_name: str,
-    revision: Optional[str] = None,
-    token: Optional[str] = None,
+    revision: str | None = None,
+    token: str | None = None,
     extension: str = ".safetensors",
-    auto_convert: bool = True,
+    auto_convert: bool | None = None,
 ) -> None:
-    from tgis_utils import hub
+    if auto_convert is None:
+        auto_convert = True
 
-    print(extension)
+    logger.info(extension)
     meta_exts = [".json", ".py", ".model", ".md"]
 
     extensions = extension.split(",")
@@ -40,167 +52,106 @@ def download_weights(
     if len(extensions) == 1 and extensions[0] not in meta_exts:
         extensions.extend(meta_exts)
 
-    files = hub.download_weights(model_name,
-                                 extensions,
-                                 revision=revision,
-                                 auth_token=token)
+    files = hub.download_weights(
+        model_name, extensions, revision=revision, auth_token=token
+    )
 
     if auto_convert and ".safetensors" in extensions:
-        if not hub.local_weight_files(hub.get_model_path(model_name, revision),
-                                      ".safetensors"):
+        if not hub.local_weight_files(
+            hub.get_model_path(model_name, revision), ".safetensors"
+        ):
             if ".bin" not in extensions:
-                print(".safetensors weights not found, \
-                    downloading pytorch weights to convert...")
-                hub.download_weights(model_name,
-                                     ".bin",
-                                     revision=revision,
-                                     auth_token=token)
+                logger.info(
+                    ".safetensors weights not found, \
+                    downloading pytorch weights to convert..."
+                )
+                hub.download_weights(
+                    model_name, ".bin", revision=revision, auth_token=token
+                )
 
-            print(".safetensors weights not found, \
-                    converting from pytorch weights...")
+            logger.info(
+                ".safetensors weights not found, \
+                    converting from pytorch weights..."
+            )
             convert_bin_to_safetensor_file(model_name, revision)
         elif not any(f.endswith(".safetensors") for f in files):
-            print(".safetensors weights not found on hub, \
-                    but were found locally. Remove them first to re-convert")
+            logger.info(
+                ".safetensors weights not found on hub, \
+                    but were found locally. Remove them first to re-convert"
+            )
     if auto_convert:
         convert_to_fast_tokenizer(model_name, revision)
 
 
-def convert_to_safetensors(
-    model_name: str,
-    revision: Optional[str] = None,
-):
-    from tgis_utils import hub
-
-    # Get local pytorch file paths
-    model_path = hub.get_model_path(model_name, revision)
-    local_pt_files = hub.local_weight_files(model_path, ".bin")
-    local_pt_index_files = hub.local_index_files(model_path, ".bin")
-    if len(local_pt_index_files) > 1:
-        print(
-            f"Found more than one .bin.index.json file: {local_pt_index_files}"
-        )
-        return
-    if not local_pt_files:
-        print("No pytorch .bin files found to convert")
-        return
-
-    local_pt_files = [Path(f) for f in local_pt_files]
-    local_pt_index_file = local_pt_index_files[
-        0] if local_pt_index_files else None
-
-    # Safetensors final filenames
-    local_st_files = [
-        p.parent / f"{p.stem.removeprefix('pytorch_')}.safetensors"
-        for p in local_pt_files
-    ]
-
-    if any(os.path.exists(p) for p in local_st_files):
-        print("Existing .safetensors weights found, \
-                remove them first to reconvert")
-        return
-
-    try:
-        import transformers
-
-        config = transformers.AutoConfig.from_pretrained(
-            model_name,
-            revision=revision,
-        )
-        architecture = config.architectures[0]
-
-        class_ = getattr(transformers, architecture)
-
-        # Name for this variable depends on transformers version
-        discard_names = getattr(class_, "_tied_weights_keys", [])
-        discard_names.extend(
-            getattr(class_, "_keys_to_ignore_on_load_missing", []))
-
-    except Exception:
-        discard_names = []
-
-    if local_pt_index_file:
-        local_pt_index_file = Path(local_pt_index_file)
-        st_prefix = local_pt_index_file.stem.removeprefix(
-            "pytorch_").removesuffix(".bin.index")
-        local_st_index_file = (local_pt_index_file.parent /
-                               f"{st_prefix}.safetensors.index.json")
-
-        if os.path.exists(local_st_index_file):
-            print("Existing .safetensors.index.json file found, \
-                    remove it first to reconvert")
-            return
-
-        hub.convert_index_file(local_pt_index_file, local_st_index_file,
-                               local_pt_files, local_st_files)
-
-    # Convert pytorch weights to safetensors
-    hub.convert_files(local_pt_files, local_st_files, discard_names)
-
-
 def convert_to_fast_tokenizer(
     model_name: str,
-    revision: Optional[str] = None,
-    output_path: Optional[str] = None,
-):
-    from tgis_utils import hub
-
+    revision: str | None = None,
+    output_path: str | None = None,
+) -> None:
     # Check for existing "tokenizer.json"
     model_path = hub.get_model_path(model_name, revision)
 
-    if os.path.exists(os.path.join(model_path, "tokenizer.json")):
-        print(f"Model {model_name} already has a fast tokenizer")
+    if Path.exists(Path(model_path) / "tokenizer.json"):
+        logger.info("Model %s already has a fast tokenizer", model_name)
         return
 
     if output_path is not None:
-        if not os.path.isdir(output_path):
-            print(f"Output path {output_path} must exist and be a directory")
+        if not Path.isdir(output_path):
+            logger.info("Output path %s must exist and be a directory", output_path)
             return
     else:
         output_path = model_path
 
     import transformers
 
-    tokenizer = transformers.AutoTokenizer.from_pretrained(model_name,
-                                                           revision=revision)
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        model_name, revision=revision
+    )
     tokenizer.save_pretrained(output_path)
 
-    print(f"Saved tokenizer to {output_path}")
+    logger.info("Saved tokenizer to %s", output_path)
 
-def main():
+
+def cli() -> None:
     parser = FlexibleArgumentParser(description="vLLM CLI")
     subparsers = parser.add_subparsers(required=True)
 
     download_weights_parser = subparsers.add_parser(
         "download-weights",
         help=("Download the weights of a given model"),
-        usage="vllm download-weights <model_name> [options]")
+        usage="vllm download-weights <model_name> [options]",
+    )
     download_weights_parser.add_argument("model_name")
     download_weights_parser.add_argument("--revision")
     download_weights_parser.add_argument("--token")
     download_weights_parser.add_argument("--extension", default=".safetensors")
     download_weights_parser.add_argument("--auto_convert", default=True)
-    download_weights_parser.set_defaults(dispatch_function=tgis_cli,
-                                         command="download-weights")
+    download_weights_parser.set_defaults(
+        dispatch_function=tgis_cli, command="download-weights"
+    )
 
     convert_to_safetensors_parser = subparsers.add_parser(
         "convert-to-safetensors",
         help=("Convert model weights to safetensors"),
-        usage="vllm convert-to-safetensors <model_name> [options]")
+        usage="vllm convert-to-safetensors <model_name> [options]",
+    )
     convert_to_safetensors_parser.add_argument("model_name")
     convert_to_safetensors_parser.add_argument("--revision")
     convert_to_safetensors_parser.set_defaults(
-        dispatch_function=tgis_cli, command="convert-to-safetensors")
+        dispatch_function=tgis_cli, command="convert-to-safetensors"
+    )
 
     convert_to_fast_tokenizer_parser = subparsers.add_parser(
         "convert-to-fast-tokenizer",
         help=("Convert to fast tokenizer"),
-        usage="vllm convert-to-fast-tokenizer <model_name> [options]")
+        usage="vllm convert-to-fast-tokenizer <model_name> [options]",
+    )
     convert_to_fast_tokenizer_parser.add_argument("model_name")
     convert_to_fast_tokenizer_parser.add_argument("--revision")
     convert_to_fast_tokenizer_parser.add_argument("--output_path")
     convert_to_fast_tokenizer_parser.set_defaults(
-        dispatch_function=tgis_cli, command="convert-to-fast-tokenizer")
+        dispatch_function=tgis_cli, command="convert-to-fast-tokenizer"
+    )
 
     args = parser.parse_args()
     # One of the sub commands should be executed.
@@ -211,4 +162,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    cli()

--- a/src/vllm_tgis_adapter/tgis_utils/scripts.py
+++ b/src/vllm_tgis_adapter/tgis_utils/scripts.py
@@ -192,7 +192,7 @@ def cli() -> None:
     download_weights_parser = subparsers.add_parser(
         "download-weights",
         help=("Download the weights of a given model"),
-        usage="adapter download-weights <model_name> [options]",
+        usage="model-util download-weights <model_name> [options]",
     )
     download_weights_parser.add_argument("model_name")
     download_weights_parser.add_argument("--revision")
@@ -206,7 +206,7 @@ def cli() -> None:
     convert_to_safetensors_parser = subparsers.add_parser(
         "convert-to-safetensors",
         help=("Convert model weights to safetensors"),
-        usage="adapter convert-to-safetensors <model_name> [options]",
+        usage="model-util convert-to-safetensors <model_name> [options]",
     )
     convert_to_safetensors_parser.add_argument("model_name")
     convert_to_safetensors_parser.add_argument("--revision")
@@ -217,7 +217,7 @@ def cli() -> None:
     convert_to_fast_tokenizer_parser = subparsers.add_parser(
         "convert-to-fast-tokenizer",
         help=("Convert to fast tokenizer"),
-        usage="adapter convert-to-fast-tokenizer <model_name> [options]",
+        usage="model-util convert-to-fast-tokenizer <model_name> [options]",
     )
     convert_to_fast_tokenizer_parser.add_argument("model_name")
     convert_to_fast_tokenizer_parser.add_argument("--revision")

--- a/src/vllm_tgis_adapter/tgis_utils/scripts.py
+++ b/src/vllm_tgis_adapter/tgis_utils/scripts.py
@@ -1,4 +1,3 @@
-# The CLI entrypoint to vLLM.
 from __future__ import annotations
 
 from pathlib import Path

--- a/src/vllm_tgis_adapter/tgis_utils/scripts.py
+++ b/src/vllm_tgis_adapter/tgis_utils/scripts.py
@@ -164,12 +164,10 @@ def convert_to_fast_tokenizer(
         logger.info("Model %s already has a fast tokenizer", model_name)
         return
 
-    if output_path is not None:
-        if not Path.isdir(output_path):
-            logger.info("Output path %s must exist and be a directory", output_path)
-            return
-    else:
-        output_path = model_path
+    if output_path is not None and not Path.isdir(output_path):
+        logger.info("Output path %s must exist and be a directory", output_path)
+        return
+    output_path = model_path
 
     import transformers
 

--- a/src/vllm_tgis_adapter/tgis_utils/scripts.py
+++ b/src/vllm_tgis_adapter/tgis_utils/scripts.py
@@ -1,0 +1,214 @@
+# The CLI entrypoint to vLLM.
+import argparse
+import os
+import signal
+import sys
+from pathlib import Path
+from typing import Optional
+
+from vllm.model_executor.model_loader.weight_utils import convert_bin_to_safetensor_file
+from vllm.scripts import registrer_signal_handlers
+from vllm.utils import FlexibleArgumentParser
+
+def tgis_cli(args: argparse.Namespace) -> None:
+    registrer_signal_handlers()
+
+    if args.command == "download-weights":
+        download_weights(args.model_name, args.revision, args.token,
+                         args.extension, args.auto_convert)
+    elif args.command == "convert-to-safetensors":
+        convert_bin_to_safetensor_file(args.model_name, args.revision)
+    elif args.command == "convert-to-fast-tokenizer":
+        convert_to_fast_tokenizer(args.model_name, args.revision,
+                                  args.output_path)
+
+
+def download_weights(
+    model_name: str,
+    revision: Optional[str] = None,
+    token: Optional[str] = None,
+    extension: str = ".safetensors",
+    auto_convert: bool = True,
+) -> None:
+    from tgis_utils import hub
+
+    print(extension)
+    meta_exts = [".json", ".py", ".model", ".md"]
+
+    extensions = extension.split(",")
+
+    if len(extensions) == 1 and extensions[0] not in meta_exts:
+        extensions.extend(meta_exts)
+
+    files = hub.download_weights(model_name,
+                                 extensions,
+                                 revision=revision,
+                                 auth_token=token)
+
+    if auto_convert and ".safetensors" in extensions:
+        if not hub.local_weight_files(hub.get_model_path(model_name, revision),
+                                      ".safetensors"):
+            if ".bin" not in extensions:
+                print(".safetensors weights not found, \
+                    downloading pytorch weights to convert...")
+                hub.download_weights(model_name,
+                                     ".bin",
+                                     revision=revision,
+                                     auth_token=token)
+
+            print(".safetensors weights not found, \
+                    converting from pytorch weights...")
+            convert_bin_to_safetensor_file(model_name, revision)
+        elif not any(f.endswith(".safetensors") for f in files):
+            print(".safetensors weights not found on hub, \
+                    but were found locally. Remove them first to re-convert")
+    if auto_convert:
+        convert_to_fast_tokenizer(model_name, revision)
+
+
+def convert_to_safetensors(
+    model_name: str,
+    revision: Optional[str] = None,
+):
+    from tgis_utils import hub
+
+    # Get local pytorch file paths
+    model_path = hub.get_model_path(model_name, revision)
+    local_pt_files = hub.local_weight_files(model_path, ".bin")
+    local_pt_index_files = hub.local_index_files(model_path, ".bin")
+    if len(local_pt_index_files) > 1:
+        print(
+            f"Found more than one .bin.index.json file: {local_pt_index_files}"
+        )
+        return
+    if not local_pt_files:
+        print("No pytorch .bin files found to convert")
+        return
+
+    local_pt_files = [Path(f) for f in local_pt_files]
+    local_pt_index_file = local_pt_index_files[
+        0] if local_pt_index_files else None
+
+    # Safetensors final filenames
+    local_st_files = [
+        p.parent / f"{p.stem.removeprefix('pytorch_')}.safetensors"
+        for p in local_pt_files
+    ]
+
+    if any(os.path.exists(p) for p in local_st_files):
+        print("Existing .safetensors weights found, \
+                remove them first to reconvert")
+        return
+
+    try:
+        import transformers
+
+        config = transformers.AutoConfig.from_pretrained(
+            model_name,
+            revision=revision,
+        )
+        architecture = config.architectures[0]
+
+        class_ = getattr(transformers, architecture)
+
+        # Name for this variable depends on transformers version
+        discard_names = getattr(class_, "_tied_weights_keys", [])
+        discard_names.extend(
+            getattr(class_, "_keys_to_ignore_on_load_missing", []))
+
+    except Exception:
+        discard_names = []
+
+    if local_pt_index_file:
+        local_pt_index_file = Path(local_pt_index_file)
+        st_prefix = local_pt_index_file.stem.removeprefix(
+            "pytorch_").removesuffix(".bin.index")
+        local_st_index_file = (local_pt_index_file.parent /
+                               f"{st_prefix}.safetensors.index.json")
+
+        if os.path.exists(local_st_index_file):
+            print("Existing .safetensors.index.json file found, \
+                    remove it first to reconvert")
+            return
+
+        hub.convert_index_file(local_pt_index_file, local_st_index_file,
+                               local_pt_files, local_st_files)
+
+    # Convert pytorch weights to safetensors
+    hub.convert_files(local_pt_files, local_st_files, discard_names)
+
+
+def convert_to_fast_tokenizer(
+    model_name: str,
+    revision: Optional[str] = None,
+    output_path: Optional[str] = None,
+):
+    from tgis_utils import hub
+
+    # Check for existing "tokenizer.json"
+    model_path = hub.get_model_path(model_name, revision)
+
+    if os.path.exists(os.path.join(model_path, "tokenizer.json")):
+        print(f"Model {model_name} already has a fast tokenizer")
+        return
+
+    if output_path is not None:
+        if not os.path.isdir(output_path):
+            print(f"Output path {output_path} must exist and be a directory")
+            return
+    else:
+        output_path = model_path
+
+    import transformers
+
+    tokenizer = transformers.AutoTokenizer.from_pretrained(model_name,
+                                                           revision=revision)
+    tokenizer.save_pretrained(output_path)
+
+    print(f"Saved tokenizer to {output_path}")
+
+def main():
+    parser = FlexibleArgumentParser(description="vLLM CLI")
+    subparsers = parser.add_subparsers(required=True)
+
+    download_weights_parser = subparsers.add_parser(
+        "download-weights",
+        help=("Download the weights of a given model"),
+        usage="vllm download-weights <model_name> [options]")
+    download_weights_parser.add_argument("model_name")
+    download_weights_parser.add_argument("--revision")
+    download_weights_parser.add_argument("--token")
+    download_weights_parser.add_argument("--extension", default=".safetensors")
+    download_weights_parser.add_argument("--auto_convert", default=True)
+    download_weights_parser.set_defaults(dispatch_function=tgis_cli,
+                                         command="download-weights")
+
+    convert_to_safetensors_parser = subparsers.add_parser(
+        "convert-to-safetensors",
+        help=("Convert model weights to safetensors"),
+        usage="vllm convert-to-safetensors <model_name> [options]")
+    convert_to_safetensors_parser.add_argument("model_name")
+    convert_to_safetensors_parser.add_argument("--revision")
+    convert_to_safetensors_parser.set_defaults(
+        dispatch_function=tgis_cli, command="convert-to-safetensors")
+
+    convert_to_fast_tokenizer_parser = subparsers.add_parser(
+        "convert-to-fast-tokenizer",
+        help=("Convert to fast tokenizer"),
+        usage="vllm convert-to-fast-tokenizer <model_name> [options]")
+    convert_to_fast_tokenizer_parser.add_argument("model_name")
+    convert_to_fast_tokenizer_parser.add_argument("--revision")
+    convert_to_fast_tokenizer_parser.add_argument("--output_path")
+    convert_to_fast_tokenizer_parser.set_defaults(
+        dispatch_function=tgis_cli, command="convert-to-fast-tokenizer")
+
+    args = parser.parse_args()
+    # One of the sub commands should be executed.
+    if hasattr(args, "dispatch_function"):
+        args.dispatch_function(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/vllm_tgis_adapter/tgis_utils/scripts.py
+++ b/src/vllm_tgis_adapter/tgis_utils/scripts.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from vllm.scripts import registrer_signal_handlers
 from vllm.utils import FlexibleArgumentParser
 
 from vllm_tgis_adapter.logging import init_logger
@@ -16,8 +15,6 @@ if TYPE_CHECKING:
 
 
 def tgis_cli(args: argparse.Namespace) -> None:
-    registrer_signal_handlers()
-
     if args.command == "download-weights":
         download_weights(
             args.model_name,

--- a/src/vllm_tgis_adapter/tgis_utils/scripts.py
+++ b/src/vllm_tgis_adapter/tgis_utils/scripts.py
@@ -1,17 +1,16 @@
 # The CLI entrypoint to vLLM.
 from __future__ import annotations
 
-import logging
+from pathlib import Path
 from typing import TYPE_CHECKING
 
-import Path
-from vllm.model_executor.model_loader.weight_utils import convert_bin_to_safetensor_file
 from vllm.scripts import registrer_signal_handlers
 from vllm.utils import FlexibleArgumentParser
 
+from vllm_tgis_adapter.logging import init_logger
 from vllm_tgis_adapter.tgis_utils import hub
 
-logger = logging.getLogger(__name__)
+logger = init_logger(__name__)
 
 if TYPE_CHECKING:
     import argparse
@@ -29,7 +28,7 @@ def tgis_cli(args: argparse.Namespace) -> None:
             args.auto_convert,
         )
     elif args.command == "convert-to-safetensors":
-        convert_bin_to_safetensor_file(args.model_name, args.revision)
+        convert_to_safetensors(args.model_name, args.revision)
     elif args.command == "convert-to-fast-tokenizer":
         convert_to_fast_tokenizer(args.model_name, args.revision, args.output_path)
 
@@ -73,7 +72,7 @@ def download_weights(
                 ".safetensors weights not found, \
                     converting from pytorch weights..."
             )
-            convert_bin_to_safetensor_file(model_name, revision)
+            convert_to_safetensors(model_name, revision)
         elif not any(f.endswith(".safetensors") for f in files):
             logger.info(
                 ".safetensors weights not found on hub, \
@@ -81,6 +80,80 @@ def download_weights(
             )
     if auto_convert:
         convert_to_fast_tokenizer(model_name, revision)
+
+
+def convert_to_safetensors(
+    model_name: str,
+    revision: str | None = None,
+) -> None:
+    # Get local pytorch file paths
+    model_path = hub.get_model_path(model_name, revision)
+    local_pt_files = hub.local_weight_files(model_path, ".bin")
+    local_pt_index_files = hub.local_index_files(model_path, ".bin")
+    if len(local_pt_index_files) > 1:
+        logger.info(
+            "Found more than one .bin.index.json file: %s", local_pt_index_files
+        )
+        return
+    if not local_pt_files:
+        logger.info("No pytorch .bin files found to convert")
+        return
+
+    local_pt_files = [Path(f) for f in local_pt_files]
+    local_pt_index_file = local_pt_index_files[0] if local_pt_index_files else None
+
+    # Safetensors final filenames
+    local_st_files = [
+        p.parent / f"{p.stem.removeprefix('pytorch_')}.safetensors"
+        for p in local_pt_files
+    ]
+
+    if any(Path.exists(p) for p in local_st_files):
+        logger.info(
+            "Existing .safetensors weights found, remove them first to reconvert"
+        )
+        return
+
+    try:
+        import transformers
+
+        config = transformers.AutoConfig.from_pretrained(
+            model_name,
+            revision=revision,
+        )
+        architecture = config.architectures[0]
+
+        class_ = getattr(transformers, architecture)
+
+        # Name for this variable depends on transformers version
+        discard_names = getattr(class_, "_tied_weights_keys", [])
+        discard_names.extend(getattr(class_, "_keys_to_ignore_on_load_missing", []))
+
+    except TypeError:
+        discard_names = []
+
+    if local_pt_index_file:
+        local_pt_index_file = Path(local_pt_index_file)
+        st_prefix = local_pt_index_file.stem.removeprefix("pytorch_").removesuffix(
+            ".bin.index"
+        )
+        local_st_index_file = (
+            local_pt_index_file.parent / f"{st_prefix}.safetensors.index.json"
+        )
+
+        if Path.exists(local_st_index_file):
+            logger.info(
+                "Existing .safetensors.index.json file found, remove it first to \
+                    reconvert"
+            )
+            return
+
+        hub.convert_index_file(
+            local_pt_index_file, local_st_index_file, local_pt_files, local_st_files
+        )
+
+    # Convert pytorch weights to safetensors
+    hub.convert_files(local_pt_files, local_st_files, discard_names)
 
 
 def convert_to_fast_tokenizer(
@@ -119,7 +192,7 @@ def cli() -> None:
     download_weights_parser = subparsers.add_parser(
         "download-weights",
         help=("Download the weights of a given model"),
-        usage="vllm download-weights <model_name> [options]",
+        usage="adapter download-weights <model_name> [options]",
     )
     download_weights_parser.add_argument("model_name")
     download_weights_parser.add_argument("--revision")
@@ -133,7 +206,7 @@ def cli() -> None:
     convert_to_safetensors_parser = subparsers.add_parser(
         "convert-to-safetensors",
         help=("Convert model weights to safetensors"),
-        usage="vllm convert-to-safetensors <model_name> [options]",
+        usage="adapter convert-to-safetensors <model_name> [options]",
     )
     convert_to_safetensors_parser.add_argument("model_name")
     convert_to_safetensors_parser.add_argument("--revision")
@@ -144,7 +217,7 @@ def cli() -> None:
     convert_to_fast_tokenizer_parser = subparsers.add_parser(
         "convert-to-fast-tokenizer",
         help=("Convert to fast tokenizer"),
-        usage="vllm convert-to-fast-tokenizer <model_name> [options]",
+        usage="adapter convert-to-fast-tokenizer <model_name> [options]",
     )
     convert_to_fast_tokenizer_parser.add_argument("model_name")
     convert_to_fast_tokenizer_parser.add_argument("--revision")

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -31,6 +31,7 @@ def test_weight_hub_files():
     assert filenames == ["model.safetensors"]
 
 
+@pytest.mark.large()
 def test_weight_hub_files_llm():
     filenames = weight_hub_files("bigscience/bloom")
     assert filenames == [f"model_{i:05d}-of-00072.safetensors" for i in range(1, 73)]

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -2,7 +2,8 @@ from pathlib import Path
 
 import pytest
 from huggingface_hub.utils import LocalEntryNotFoundError
-from tgis_utils.hub import (
+
+from vllm_tgis_adapter.tgis_utils.hub import (
     convert_files,
     download_weights,
     weight_files,

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -10,9 +10,11 @@ from vllm_tgis_adapter.tgis_utils.hub import (
     weight_hub_files,
 )
 
+pytestmark = pytest.mark.hf_data
+
 
 def test_convert_files():
-    model_id = "bigscience/bloom-560m"
+    model_id = "facebook/opt-125m"
     local_pt_files = download_weights(model_id, extension=".bin")
     local_pt_files = [Path(p) for p in local_pt_files]
     local_st_files = [
@@ -27,11 +29,10 @@ def test_convert_files():
 
 
 def test_weight_hub_files():
-    filenames = weight_hub_files("bigscience/bloom-560m")
+    filenames = weight_hub_files("facebook/opt-125m")
     assert filenames == ["model.safetensors"]
 
 
-@pytest.mark.large()
 def test_weight_hub_files_llm():
     filenames = weight_hub_files("bigscience/bloom")
     assert filenames == [f"model_{i:05d}-of-00072.safetensors" for i in range(1, 73)]
@@ -43,8 +44,8 @@ def test_weight_hub_files_empty():
 
 
 def test_download_weights():
-    files = download_weights("bigscience/bloom-560m")
-    local_files = weight_files("bigscience/bloom-560m")
+    files = download_weights("facebook/opt-125m")
+    local_files = weight_files("facebook/opt-125m")
     assert files == local_files
 
 

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+import pytest
+from huggingface_hub.utils import LocalEntryNotFoundError
+
+from tgis_utils.hub import (convert_files, download_weights, weight_files,
+                                 weight_hub_files)
+
+
+def test_convert_files():
+    model_id = "bigscience/bloom-560m"
+    local_pt_files = download_weights(model_id, extension=".bin")
+    local_pt_files = [Path(p) for p in local_pt_files]
+    local_st_files = [
+        p.parent / f"{p.stem.removeprefix('pytorch_')}.safetensors"
+        for p in local_pt_files
+    ]
+    convert_files(local_pt_files, local_st_files, discard_names=[])
+
+    found_st_files = weight_files(model_id)
+
+    assert all([str(p) in found_st_files for p in local_st_files])
+
+
+def test_weight_hub_files():
+    filenames = weight_hub_files("bigscience/bloom-560m")
+    assert filenames == ["model.safetensors"]
+
+
+def test_weight_hub_files_llm():
+    filenames = weight_hub_files("bigscience/bloom")
+    assert filenames == [
+        f"model_{i:05d}-of-00072.safetensors" for i in range(1, 73)
+    ]
+
+
+def test_weight_hub_files_empty():
+    filenames = weight_hub_files("bigscience/bloom", ".errors")
+    assert filenames == []
+
+
+def test_download_weights():
+    files = download_weights("bigscience/bloom-560m")
+    local_files = weight_files("bigscience/bloom-560m")
+    assert files == local_files
+
+
+def test_weight_files_error():
+    with pytest.raises(LocalEntryNotFoundError):
+        weight_files("bert-base-uncased")

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -2,9 +2,12 @@ from pathlib import Path
 
 import pytest
 from huggingface_hub.utils import LocalEntryNotFoundError
-
-from tgis_utils.hub import (convert_files, download_weights, weight_files,
-                                 weight_hub_files)
+from tgis_utils.hub import (
+    convert_files,
+    download_weights,
+    weight_files,
+    weight_hub_files,
+)
 
 
 def test_convert_files():
@@ -19,7 +22,7 @@ def test_convert_files():
 
     found_st_files = weight_files(model_id)
 
-    assert all([str(p) in found_st_files for p in local_st_files])
+    assert all(str(p) in found_st_files for p in local_st_files)
 
 
 def test_weight_hub_files():
@@ -29,9 +32,7 @@ def test_weight_hub_files():
 
 def test_weight_hub_files_llm():
     filenames = weight_hub_files("bigscience/bloom")
-    assert filenames == [
-        f"model_{i:05d}-of-00072.safetensors" for i in range(1, 73)
-    ]
+    assert filenames == [f"model_{i:05d}-of-00072.safetensors" for i in range(1, 73)]
 
 
 def test_weight_hub_files_empty():


### PR DESCRIPTION
- Supersedes https://github.com/IBM/vllm/pull/16, https://github.com/IBM/vllm/pull/52, https://github.com/opendatahub-io/vllm/pull/92

- Related to: https://github.com/vllm-project/vllm/pull/5090

Changes:
- Adds commands to the adapter using either entry point `model-util` or `text-generation-server` 
  * `model-util download-weights`
  * `model-util convert-to-safetensors`
  * `model-util convert-to-fast-tokenizer`