### PR TITLE
vLLM 5.3+ support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,7 +32,7 @@ jobs:
         pyv: ["3.11"]
         vllm_version:
           # - "" # skip the pypi version as it will not work on CPU
-          - "git+https://github.com/vllm-project/vllm@v0.5.2"
+          - "git+https://github.com/vllm-project/vllm@v0.5.3.post1"
           - "git+https://github.com/vllm-project/vllm@main"
           - "git+https://github.com/opendatahub-io/vllm@main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
   "grpcio==1.62.2",
   "grpcio-health-checking==1.62.2",
   "grpcio-reflection==1.62.2",
-  "transformers==4.42.4",
   "accelerate==0.32.1",
   "hf-transfer==0.1.6",
   # additional dependencies for OpenTelemetry tracing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 requires-python = ">=3.9"
 dynamic = ["version"]
 dependencies = [
-  "vllm>=0.5.2",
+  "vllm>=0.5.3.post1",
   "prometheus_client==0.20.0",
   "grpcio==1.62.2",
   "grpcio-health-checking==1.62.2",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds the necessary changes (that I found, at least) to run the adapter with vllm 0.5.3.

The main change was the removal of `TextTokensPrompt`, it was removed with this PR: https://github.com/vllm-project/vllm/commit/739b61a348afa5da297a80ff15f4e39d6e524b53
I'm not 100% sure if simply replacing with `LLMInputs` is the correct fix here, but it does seem to work. (I think I see some more complex processing happening on the upstream openai serving engine)

The initializers for all of the `OpenAIServing*` classes changed, I copied over the new defs from upstream.

Also I noticed that there was no initialization for the tokenizer, so I added it.

## How Has This Been Tested?
Booting up a pod with a mig gpu slice, installing vllm@5.3 and vllm-tgis-adapter@llm-inputs, and running the default facebook/opt-125m model with `python3 -m vllm_tgis_adapter`.

Requests sent using the swagger page at `/docs` and grpcui (though grpc should be unaffected)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
