### PR TITLE
:goal_net: Kill servers on engine death

### DIFF
--- a/src/vllm_tgis_adapter/grpc/grpc_server.py
+++ b/src/vllm_tgis_adapter/grpc/grpc_server.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import os
+import signal
 import time
 import uuid
 from collections.abc import Callable, Coroutine
@@ -112,6 +113,18 @@ async def _handle_exception(
 ) -> None:
     context: ServicerContext = kwargs.get("context", None) or args[-1]
     is_generate_fn = "generate" in func.__name__.lower()
+
+    # self.engine on the servicer
+    engine = args[0].engine
+    # If the engine has died, then the server cannot process any further
+    # requests. We want to immediately stop the process in this case to avoid
+    # any downtime while waiting for probes to fail.
+    if engine.errored and not engine.is_running:
+        # awaiting a server.stop() in here won't work because we're in
+        # the context of a running request.
+        # SIGTERM is a bit rough, but will signal the process to gracefully
+        # shut down both the grpc and http servers.
+        os.kill(os.getpid(), signal.SIGTERM)
 
     # First just try to replicate the TGIS-style log messages
     # for generate_* rpcs

--- a/src/vllm_tgis_adapter/grpc/grpc_server.py
+++ b/src/vllm_tgis_adapter/grpc/grpc_server.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import inspect
 import os
-import signal
 import time
 import uuid
 from collections.abc import Callable, Coroutine
@@ -113,9 +112,10 @@ async def _handle_exception(
     if engine.errored and not engine.is_running:
         # awaiting a server.stop() in here won't work because we're in
         # the context of a running request.
-        # SIGTERM is a bit rough, but will signal the process to gracefully
-        # shut down both the grpc and http servers.
-        os.kill(os.getpid(), signal.SIGTERM)
+        # Instead we set an event to signal another coroutine to stop the
+        # server.
+        stop_event = args[0].stop_event
+        stop_event.set()
 
     # First just try to replicate the TGIS-style log messages
     # for generate_* rpcs
@@ -180,8 +180,10 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
         engine: AsyncEngineClient | AsyncLLMEngine,
         args: argparse.Namespace,
         health_servicer: health.HealthServicer,
+        stop_event: asyncio.Event,
     ):
         self.engine: AsyncEngineClient = engine
+        self.stop_event = stop_event
 
         # This is set in post_init()
         self.config: ModelConfig | None = None
@@ -883,13 +885,14 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
 async def start_grpc_server(
     args: argparse.Namespace,
     engine: AsyncLLMEngine | AsyncEngineClient,
+    stop_event: asyncio.Event,
 ) -> aio.Server:
     server = aio.server()
 
     health_servicer = health.HealthServicer()
     health_pb2_grpc.add_HealthServicer_to_server(health_servicer, server)
 
-    generation = TextGenerationService(engine, args, health_servicer)
+    generation = TextGenerationService(engine, args, health_servicer, stop_event)
     await generation.post_init()
     generation_pb2_grpc.add_GenerationServiceServicer_to_server(generation, server)
 
@@ -949,14 +952,20 @@ async def run_grpc_server(
     args: argparse.Namespace,
     engine: AsyncEngineClient | AsyncLLMEngine,
 ) -> None:
-    server = await start_grpc_server(
-        args,
-        engine,
-    )
+    stop_event = asyncio.Event()
+    server = await start_grpc_server(args, engine, stop_event)
+
+    # Add a task to watch for the stop event, so that the server can kill
+    # itself from within its own handlers
+    async def wait_for_server_shutdown() -> None:
+        await stop_event.wait()
+        # Kill with no grace period because the engine is dead
+        await server.stop(0)
 
     try:
-        while True:
-            await asyncio.sleep(10)
+        # Either the server stops itself,
+        # Or the task running this coroutine gets cancelled
+        await wait_for_server_shutdown()
     except asyncio.CancelledError:
         print("Gracefully stopping gRPC server")  # noqa: T201
         await server.stop(30)  # TODO configurable grace

--- a/src/vllm_tgis_adapter/http.py
+++ b/src/vllm_tgis_adapter/http.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import asyncio
 from typing import TYPE_CHECKING
 
-import uvicorn
+from vllm.entrypoints.launcher import serve_http
 from vllm.entrypoints.openai.api_server import (
     init_app,
 )
@@ -12,37 +11,12 @@ from vllm.logger import init_logger
 if TYPE_CHECKING:
     import argparse
 
-    from fastapi import FastAPI
     from vllm.engine.async_llm_engine import AsyncLLMEngine
     from vllm.engine.protocol import AsyncEngineClient
 
 TIMEOUT_KEEP_ALIVE = 5  # seconds
 
 logger = init_logger(__name__)
-
-
-async def serve_http(
-    app: FastAPI,
-    **uvicorn_kwargs,  # noqa: ANN003
-) -> None:
-    logger.info("Available routes are:")
-    for route in app.routes:
-        methods = getattr(route, "methods", None)
-        path = getattr(route, "path", None)
-
-        if methods is None or path is None:
-            continue
-
-        logger.info("Route: %s, Methods: %s", path, ", ".join(methods))
-
-    config = uvicorn.Config(app, **uvicorn_kwargs)
-    server = uvicorn.Server(config)
-
-    try:
-        await server.serve()
-    except asyncio.CancelledError:
-        logger.info("Gracefully stopping http server")
-        await server.shutdown()
 
 
 async def run_http_server(
@@ -57,6 +31,7 @@ async def run_http_server(
 
     await serve_http(
         app,
+        engine,
         host=args.host,
         port=args.port,
         log_level=args.uvicorn_log_level,

--- a/src/vllm_tgis_adapter/http.py
+++ b/src/vllm_tgis_adapter/http.py
@@ -29,16 +29,25 @@ async def run_http_server(
 
     app = await init_app(engine, args)  # type: ignore[arg-type]
 
-    await serve_http(
-        app,
-        engine,
-        host=args.host,
-        port=args.port,
-        log_level=args.uvicorn_log_level,
-        timeout_keep_alive=TIMEOUT_KEEP_ALIVE,
-        ssl_keyfile=args.ssl_keyfile,
-        ssl_certfile=args.ssl_certfile,
-        ssl_ca_certs=args.ssl_ca_certs,
-        ssl_cert_reqs=args.ssl_cert_reqs,
-        **uvicorn_kwargs,
-    )
+    serve_kwargs = {
+        "host": args.host,
+        "port": args.port,
+        "log_level": args.uvicorn_log_level,
+        "timeout_keep_alive": TIMEOUT_KEEP_ALIVE,
+        "ssl_keyfile": args.ssl_keyfile,
+        "ssl_certfile": args.ssl_certfile,
+        "ssl_ca_certs": args.ssl_ca_certs,
+        "ssl_cert_reqs": args.ssl_cert_reqs,
+    }
+    serve_kwargs.update(uvicorn_kwargs)
+
+    try:
+        shutdown_coro = await serve_http(app, engine, **serve_kwargs)
+    except TypeError:
+        # vllm 0.5.4 backwards compatibility
+        # HTTP server will not shut itself down when the engine dies
+        shutdown_coro = await serve_http(app, **serve_kwargs)
+
+    # launcher.serve_http returns a shutdown coroutine to await
+    # (The double await is intentional)
+    await shutdown_coro


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
See https://github.com/vllm-project/vllm/pull/6594

This PR modifies the grpc server's exception handler to check if the async llm engine is still running.
If it's not then the handler sends a SIGTERM to kill the serving process, which should trigger the graceful shutdown handlers.

This approach is a bit heavy-handed, but `await server.stop(0)` seems very unhappy if called within the context of a request handler. Maybe we could use some grpc context termination callbacks for this, but I didn't really think it was worth the time to investigate that too deeply. I think the only real drawback here is that unit testing this feature would be pretty difficult with an `os.kill` in the mix.

This PR currently does _not_ add this handling to the http server, but once PRs 6594 and https://github.com/vllm-project/vllm/pull/6740 are merged, we should be able to remove our copy-pasta http server so both will handle engine death properly.

## How Has This Been Tested?
Tested by installing vllm==0.5.3.post1 and the adapter from this branch onto a dev pod, injecting a runtime failure into the llm engine, and running a grpc request.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
