### PR TITLE
Make ADD_SPECIAL_TOKENS true by default

### DIFF
--- a/src/vllm_tgis_adapter/grpc/grpc_server.py
+++ b/src/vllm_tgis_adapter/grpc/grpc_server.py
@@ -85,9 +85,10 @@ _F = TypeVar("_F", Callable, Coroutine)
 logger = init_logger(__name__)
 service_metrics = ServiceMetrics()
 
-ADD_SPECIAL_TOKENS: str | None = os.getenv("ADD_SPECIAL_TOKENS")
-if ADD_SPECIAL_TOKENS is not None:
-    ADD_SPECIAL_TOKENS = ADD_SPECIAL_TOKENS.lower() not in (0, "false")
+ADD_SPECIAL_TOKENS: bool = os.getenv("ADD_SPECIAL_TOKENS", "true").lower() not in (
+    "0",
+    "false",
+)
 
 
 def with_default(value: _T, default: _T) -> _T:
@@ -745,15 +746,7 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
 
         max_model_len = self.config.max_model_len
 
-        # Add special tokens based on env var or else only if the tokenizer
-        # does not have a chat template => this is not a chat model
-        add_special_tokens = (
-            ADD_SPECIAL_TOKENS
-            if ADD_SPECIAL_TOKENS is not None
-            else not tokenizer.chat_template
-        )
-
-        tokenizer_kwargs: dict[str, Any] = {"add_special_tokens": add_special_tokens}
+        tokenizer_kwargs: dict[str, Any] = {"add_special_tokens": ADD_SPECIAL_TOKENS}
         if truncate_input_tokens is not None:
             tokenizer_kwargs.update(
                 {


### PR DESCRIPTION
Before this change the ADD_SPECIAL_TOKENS acted as a tristate variable where the default (not set) would be to add special tokens only if the model didn't have a chat template.

However, this this default broke existing integration tests so, after some deliberation,  the decision was made to make the default to be "true". Due to the way that environment variables work, this means that this setting now only has 2 states: true and false.
