### PR TITLE
gha: add missing build dependencies

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,6 +48,10 @@ jobs:
           tool-cache: false
           large-packages: false
           docker-images: false
+      - name: Install vLLM build deps
+        run: |
+          sudo apt update
+          sudo apt install --no-install-recommends -y libnuma-dev
 
       - name: Set up Python ${{ matrix.pyv }}
         uses: actions/setup-python@v5


### PR DESCRIPTION
Related to https://github.com/vllm-project/vllm/pull/6125

Note that is only required for the CPU-only version

fixes [RHOAIENG-10663](https://issues.redhat.com/browse/RHOAIENG-10663)