### PR TITLE
♻️ refactor LoRARequest based on upstream

### DIFF
--- a/src/vllm_tgis_adapter/grpc/adapters.py
+++ b/src/vllm_tgis_adapter/grpc/adapters.py
@@ -76,7 +76,7 @@ async def validate_adapters(
     # grab the type out of the adapter_config.json file
     if (adapter_metadata := adapter_store.adapters.get(adapter_id)) is None:
         _reject_bad_adapter_id(adapter_id)
-        local_adapter_path = Path(adapter_store.cache_path) / adapter_id
+        local_adapter_path = str(Path(adapter_store.cache_path) / adapter_id)
 
         loop = asyncio.get_running_loop()
         if global_thread_pool is None:
@@ -104,7 +104,7 @@ async def validate_adapters(
         lora_request = LoRARequest(
             lora_name=adapter_id,
             lora_int_id=adapter_metadata.unique_id,
-            lora_local_path=adapter_metadata.full_path,
+            lora_path=adapter_metadata.full_path,
         )
         return {"lora_request": lora_request}
     if adapter_metadata.adapter_type == "PROMPT_TUNING":


### PR DESCRIPTION
Changes need to be done based on this: https://github.com/vllm-project/vllm/pull/6234
```
ERROR 07-31 22:37:30 async_llm_engine.py:56] UnboundLocalError: cannot access local variable 'lora_path' where it is not associated with a value
Exception in callback _log_task_completion(error_callback=<bound method...7f8825413c10>>)(<Task finishe...ith a value")>) at /home/develop/.conda/envs/vllm/lib/python3.11/site-packages/vllm/engine/async_llm_engine.py:36
handle: <Handle _log_task_completion(error_callback=<bound method...7f8825413c10>>)(<Task finishe...ith a value")>) at /home/develop/.conda/envs/vllm/lib/python3.11/site-packages/vllm/engine/async_llm_engine.py:36>
Traceback (most recent call last):
  File "/home/develop/.conda/envs/vllm/lib/python3.11/site-packages/vllm/lora/worker_manager.py", line 93, in _load_adapter
    lora_path = get_adapter_absolute_path(lora_request.lora_path)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/develop/.conda/envs/vllm/lib/python3.11/site-packages/vllm/lora/utils.py", line 136, in get_adapter_absolute_path
    if lora_path.startswith('~'):
       ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'PosixPath' object has no attribute 'startswith'
```