### PR TITLE
pyproject: fix broken URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ dependencies = [
 ]
 
 [project.urls]
-Issues = "https://github.com/opendatahub-io/vllm_tgis_adapter/issues"
-Source = "https://github.com/opendatahub-io/vllm_tgis_adapter"
+Issues = "https://github.com/opendatahub-io/vllm-tgis-adapter/issues"
+Source = "https://github.com/opendatahub-io/vllm-tgis-adapter"
 
 [project.scripts]
 grpc_healthcheck = "vllm_tgis_adapter.healthcheck:cli"


### PR DESCRIPTION
fixes broken urls on [PyPi](https://pypi.org/project/vllm-tgis-adapter/)
