### PR TITLE
Fix length penalty logit processor getting NaN

### DIFF
--- a/src/vllm_tgis_adapter/tgis_utils/logits_processors.py
+++ b/src/vllm_tgis_adapter/tgis_utils/logits_processors.py
@@ -35,8 +35,9 @@ class ExpDecayLengthPenaltyWarper:
         token_ids: list[int],
         logits: torch.Tensor,
     ) -> torch.Tensor:
-        tokens_past = len(token_ids) - self.start
-        if tokens_past > 0:
+        tokens_past = max(0, len(token_ids) - self.start)
+        p_factor = pow(self.penalty, tokens_past)
+        if p_factor != 1:
             eos_logit = logits[self.eos_token_id]
             # To support negative logits we compute the penalty of the
             # absolute value and add to the original logit

--- a/src/vllm_tgis_adapter/tgis_utils/logits_processors.py
+++ b/src/vllm_tgis_adapter/tgis_utils/logits_processors.py
@@ -42,6 +42,6 @@ class ExpDecayLengthPenaltyWarper:
             # To support negative logits we compute the penalty of the
             # absolute value and add to the original logit
             logits[self.eos_token_id] = eos_logit + torch.abs(eos_logit) * (
-                pow(self.penalty, tokens_past) - 1
+                p_factor - 1
             )
         return logits


### PR DESCRIPTION
There is a corner case in length penalty that make it generate NaN when the eos_token is `-inf` and the parameter `penalty` from input is 1. In this case the code for this logit processor will try to multiply `inf * 0` which is NaN. 

The following code can reproduce the issue.

```py
import math

from pb import generation_pb2_grpc as gpb2, generation_pb2 as pb2
import grpc

SERVER = 'localhost'
PORT = 8033

server = SERVER
port = int(PORT)

channel = grpc.insecure_channel(f"{server}:{port}")
stub = gpb2.GenerationServiceStub(channel)

decoding_method = pb2.SAMPLE

sampling_params = pb2.SamplingParameters(
    temperature = 1.0,
    top_k       = 0,
    top_p       = 1,
    typical_p   = 0.5,
    seed        = 123
)
decoding_parameters = pb2.DecodingParameters (
    repetition_penalty = 1,
    length_penalty = pb2.DecodingParameters.LengthPenalty(
        start_index = 0,
        decay_factor = 1,
    )
)

params = pb2.Parameters(
    method=decoding_method,
    sampling=sampling_params if decoding_method==pb2.SAMPLE else None,
    stopping=pb2.StoppingCriteria(
        min_new_tokens=50,
        max_new_tokens=1000,
    ),
    response=pb2.ResponseOptions (
       generated_tokens=True,
       input_tokens=True,
       token_logprobs=True,
       token_ranks=True,
       top_n_tokens=5,
    ),
    decoding=decoding_parameters,
)

requests = ["How to make pizza?"]

batch = pb2.BatchedGenerationRequest(
        model_id="facebook/opt-125m",
        params=params,
        requests=[
            pb2.GenerationRequest(text=request) for request in requests
        ],
    )

responses = stub.Generate(batch).responses

for res in responses:
    print(res.text)
    print('____')
    for idx, tok in enumerate(res.tokens):
        if math.isnan(tok.logprob) or any([math.isnan(t.logprob) for t in tok.top_tokens]):
            toptokens_str = ['({},{})'.format(t.text, t.logprob) for t in tok.top_tokens]
            print('Found nan in index {}'.format(idx), 'text: {}; logprob: {}; toptokens: {}'.format(tok.text, tok.logprob, toptokens_str))
            
        
            
channel.close()
```