### PR TITLE
fix merge_async_iterators usage for vLLM>0.5.4

### DIFF
--- a/src/vllm_tgis_adapter/grpc/grpc_server.py
+++ b/src/vllm_tgis_adapter/grpc/grpc_server.py
@@ -257,9 +257,18 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
             )
 
         # TODO handle cancellation
-        result_generator: AsyncIterator[tuple[int, RequestOutput]] = (
-            merge_async_iterators(*generators)
-        )
+        result_generator: AsyncIterator[tuple[int, RequestOutput]]
+
+        kwargs = {}
+        if "is_cancelled" in inspect.signature(merge_async_iterators).parameters:
+            # vllm > 0.5.4
+
+            async def is_cancelled() -> bool:
+                return context.cancelled()
+
+            kwargs["is_cancelled"] = is_cancelled
+
+        result_generator = merge_async_iterators(*generators, **kwargs)
 
         resp_options = request.params.response
         responses: list = [None] * request_count


### PR DESCRIPTION
`merge_async_iterators` now has an additional `is_cancelled` kwarg:

https://github.com/vllm-project/vllm/blob/main/vllm/utils.py#L405-L417