### PR TITLE
Revert "fix merge_async_iterators usage for vLLM>0.5.4"

### DIFF
--- a/src/vllm_tgis_adapter/grpc/grpc_server.py
+++ b/src/vllm_tgis_adapter/grpc/grpc_server.py
@@ -255,18 +255,9 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
             )
 
         # TODO handle cancellation
-        result_generator: AsyncIterator[tuple[int, RequestOutput]]
-
-        kwargs = {}
-        if "is_cancelled" in inspect.signature(merge_async_iterators).parameters:
-            # vllm > 0.5.4
-
-            async def is_cancelled() -> bool:
-                return context.cancelled()
-
-            kwargs["is_cancelled"] = is_cancelled
-
-        result_generator = merge_async_iterators(*generators, **kwargs)
+        result_generator: AsyncIterator[tuple[int, RequestOutput]] = (
+            merge_async_iterators(*generators)
+        )
 
         resp_options = request.params.response
         responses: list = [None] * request_count


### PR DESCRIPTION
This reverts commit 09290e6791db9ea0365506903b7c42f0d0205f64.

The mandatory `is_cancelled` kwarg was made optional in https://github.com/vllm-project/vllm/pull/7282