### PR TITLE
fix parsing of env vars

### DIFF
--- a/src/vllm_tgis_adapter/tgis_utils/args.py
+++ b/src/vllm_tgis_adapter/tgis_utils/args.py
@@ -26,6 +26,8 @@ def _switch_action_default(action: argparse.Action) -> None:
         val = env_val.lower() == "true" or env_val == "1"
     elif action.type is int:
         val = int(env_val)
+    else:
+        val = env_val
     action.default = val
 
 

--- a/tests/test_tgis_utils.py
+++ b/tests/test_tgis_utils.py
@@ -1,0 +1,65 @@
+import sys
+
+import pytest
+from vllm.utils import FlexibleArgumentParser
+
+from vllm_tgis_adapter.tgis_utils.args import EnvVarArgumentParser
+
+
+class TestEnvVarArgumentParser:
+    @pytest.fixture(autouse=True)
+    def _override_sys_argv(self, monkeypatch):
+        # Required to avoid parsing pytest's commandline
+        monkeypatch.setattr(sys, "argv", ["vllm_tgis_adapter"])
+
+    def test_str_flag(self, monkeypatch, _override_sys_argv):
+        expected_value = "custom-value"
+        with monkeypatch.context():
+            monkeypatch.setenv("DUMMY_FLAG", expected_value)
+
+            parser = FlexibleArgumentParser("testing parser")
+            parser.add_argument("--dummy-flag", type=str, default="default_value")
+            parser = EnvVarArgumentParser(parser=parser)
+            args = parser.parse_args()
+            assert args.dummy_flag == expected_value
+
+    @pytest.mark.parametrize(
+        ("env_var", "expected"),
+        [
+            ("True", True),
+            ("true", True),
+            ("TRUE", True),
+            ("1", True),
+            ("false", False),
+            ("False", False),
+            ("FALSE", False),
+            ("0", False),
+        ],
+    )
+    def test_bool_flag(self, monkeypatch, _override_sys_argv, env_var, expected):
+        with monkeypatch.context():
+            monkeypatch.setenv("DUMMY_BOOL_FLAG", env_var)
+
+            parser = FlexibleArgumentParser("testing parser")
+            parser.add_argument("--dummy-bool-flag", type=bool)
+            parser = EnvVarArgumentParser(parser=parser)
+            args = parser.parse_args()
+            assert args.dummy_bool_flag == expected
+
+    @pytest.mark.parametrize(
+        ("env_var", "expected"),
+        [
+            ("1", 1),
+            ("42", 42),
+            ("-1", -1),
+        ],
+    )
+    def test_int_flag(self, monkeypatch, _override_sys_argv, env_var, expected):
+        with monkeypatch.context():
+            monkeypatch.setenv("DUMMY_INT_FLAG", env_var)
+
+            parser = FlexibleArgumentParser("testing parser")
+            parser.add_argument("--dummy-int-flag", type=int)
+            parser = EnvVarArgumentParser(parser=parser)
+            args = parser.parse_args()
+            assert args.dummy_int_flag == expected


### PR DESCRIPTION
Missing `else` condition was causing a crash whenever configuration was provided via env vars:

```bash
$ ADAPTER_CACHE=/tmp/cache python -m vllm_tgis_adapter
```
```python
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/develop/.conda/envs/vllm/lib/python3.11/site-packages/vllm_tgis_adapter/__main__.py", line 64, in <module>
    parser = add_tgis_args(parser)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/home/develop/.conda/envs/vllm/lib/python3.11/site-packages/vllm_tgis_adapter/tgis_utils/args.py", line 125, in add_tgis_args
    parser.add_argument("--adapter-cache", type=str)
  File "/home/develop/.conda/envs/vllm/lib/python3.11/argparse.py", line 1473, in add_argument
    return self._add_action(action)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/develop/.conda/envs/vllm/lib/python3.11/site-packages/vllm_tgis_adapter/tgis_utils/args.py", line 65, in _add_action
    _switch_action_default(action)
  File "/home/develop/.conda/envs/vllm/lib/python3.11/site-packages/vllm_tgis_adapter/tgis_utils/args.py", line 29, in _switch_action_default
    action.default = val
                     ^^^
UnboundLocalError: cannot access local variable 'val' where it is not associated with a value 
```