### PR TITLE
feat: add --disable-prompt-logprobs argument

### DIFF
--- a/src/vllm_tgis_adapter/grpc/grpc_server.py
+++ b/src/vllm_tgis_adapter/grpc/grpc_server.py
@@ -191,6 +191,7 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
         self.max_max_new_tokens = args.max_new_tokens
         self.skip_special_tokens = not args.output_special_tokens
         self.default_include_stop_seqs = args.default_include_stop_seqs
+        self.disable_prompt_logprobs = args.disable_prompt_logprobs
 
         # Backwards compatibility for TGIS: PREFIX_STORE_PATH
         adapter_cache_path = args.adapter_cache or args.prefix_store_path
@@ -606,7 +607,8 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
         try:
             sampling_params = SamplingParams(
                 logprobs=logprobs,
-                prompt_logprobs=logprobs if resp_options.input_tokens else None,
+                prompt_logprobs=logprobs if not self.disable_prompt_logprobs and resp_options.input_tokens \
+                                         else None,
                 max_tokens=max_new_tokens,
                 min_tokens=min_new_tokens,
                 repetition_penalty=with_default(decoding.repetition_penalty, 1.0),

--- a/src/vllm_tgis_adapter/grpc/grpc_server.py
+++ b/src/vllm_tgis_adapter/grpc/grpc_server.py
@@ -607,8 +607,9 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
         try:
             sampling_params = SamplingParams(
                 logprobs=logprobs,
-                prompt_logprobs=logprobs if not self.disable_prompt_logprobs and resp_options.input_tokens \
-                                         else None,
+                prompt_logprobs=logprobs
+                if not self.disable_prompt_logprobs and resp_options.input_tokens
+                else None,
                 max_tokens=max_new_tokens,
                 min_tokens=min_new_tokens,
                 repetition_penalty=with_default(decoding.repetition_penalty, 1.0),

--- a/src/vllm_tgis_adapter/tgis_utils/args.py
+++ b/src/vllm_tgis_adapter/tgis_utils/args.py
@@ -136,6 +136,8 @@ def add_tgis_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     parser.add_argument("--speculator-max-batch-size", type=int)
     # allow re-enabling vllm native per-request logging
     parser.add_argument("--enable-vllm-log-requests", type=bool, default=False)
+    # set to true to disable producing prompt logprobs on all requests
+    parser.add_argument("--disable-prompt-logprobs", type=bool, default=False)
 
     # TODO check/add other args here
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a new `--disable-prompt-logprobs` boolean argument that defaults to False. When set to True, `prompt_logprobs` will always be set to `None` in the SamplingParams, regardless of the incoming request parameters, disabling all usage of prompt logprobs.

This flag is being added because computation of prompt logprobs can add latency to request processing and there are a couple of bugs/crashes that occur when using prompt logprobs.

## How Has This Been Tested?
Manually tested to verify that the flag can be set via env var and that it has the desired effect to not return prompt logprobs (but still returns logprobs on generated tokens).

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
