### PR TITLE
fix: consistent env var parsing for all boolean args in vLLM

### DIFF
--- a/tests/test_tgis_utils.py
+++ b/tests/test_tgis_utils.py
@@ -1,9 +1,13 @@
 import sys
 
 import pytest
+from vllm.engine.arg_utils import StoreBoolean
 from vllm.utils import FlexibleArgumentParser
 
-from vllm_tgis_adapter.tgis_utils.args import EnvVarArgumentParser
+from vllm_tgis_adapter.tgis_utils.args import (
+    EnvVarArgumentParser,
+    _bool_from_string,
+)
 
 
 class TestEnvVarArgumentParser:
@@ -45,6 +49,105 @@ class TestEnvVarArgumentParser:
             parser = EnvVarArgumentParser(parser=parser)
             args = parser.parse_args()
             assert args.dummy_bool_flag == expected
+
+    @pytest.mark.parametrize(
+        ("env_var", "expected"),
+        [
+            ("True", True),
+            ("true", True),
+            ("TRUE", True),
+            ("1", True),
+            ("false", False),
+            ("False", False),
+            ("FALSE", False),
+            ("0", False),
+        ],
+    )
+    def test_bool_from_string_flag(
+        self, monkeypatch, _override_sys_argv, env_var, expected
+    ):
+        with monkeypatch.context():
+            monkeypatch.setenv("DUMMY_BOOL_FROM_STRING_FLAG", env_var)
+
+            parser = FlexibleArgumentParser("testing parser")
+            parser.add_argument("--dummy-bool-from-string-flag", type=_bool_from_string)
+            parser = EnvVarArgumentParser(parser=parser)
+            args = parser.parse_args()
+            assert args.dummy_bool_from_string_flag == expected
+
+    @pytest.mark.parametrize(
+        ("env_var", "expected"),
+        [
+            ("True", True),
+            ("true", True),
+            ("TRUE", True),
+            ("1", True),
+            ("false", False),
+            ("False", False),
+            ("FALSE", False),
+            ("0", False),
+        ],
+    )
+    def test_store_true_flag(self, monkeypatch, _override_sys_argv, env_var, expected):
+        """VLLM has 'store_true' boolean args that we want to handle."""
+        with monkeypatch.context():
+            monkeypatch.setenv("DUMMY_STORE_TRUE_FLAG", env_var)
+
+            parser = FlexibleArgumentParser("testing parser")
+            parser.add_argument("--dummy-store-true-flag", action="store_true")
+            parser = EnvVarArgumentParser(parser=parser)
+            args = parser.parse_args()
+            assert args.dummy_store_true_flag == expected
+
+    @pytest.mark.parametrize(
+        ("env_var", "expected"),
+        [
+            ("True", True),
+            ("true", True),
+            ("TRUE", True),
+            ("1", True),
+            ("false", False),
+            ("False", False),
+            ("FALSE", False),
+            ("0", False),
+        ],
+    )
+    def test_store_false_flag(self, monkeypatch, _override_sys_argv, env_var, expected):
+        """VLLM doesn't have 'store_false' boolean args yet..."""
+        with monkeypatch.context():
+            monkeypatch.setenv("DUMMY_STORE_FALSE_FLAG", env_var)
+
+            parser = FlexibleArgumentParser("testing parser")
+            parser.add_argument("--dummy-store-false-flag", action="store_false")
+            parser = EnvVarArgumentParser(parser=parser)
+            args = parser.parse_args()
+            assert args.dummy_store_false_flag == expected
+
+    @pytest.mark.parametrize(
+        ("env_var", "expected"),
+        [
+            ("True", True),
+            ("true", True),
+            ("TRUE", True),
+            ("1", True),
+            ("false", False),
+            ("False", False),
+            ("FALSE", False),
+            ("0", False),
+        ],
+    )
+    def test_store_boolean_flag(
+        self, monkeypatch, _override_sys_argv, env_var, expected
+    ):
+        """VLLM has a custom StoreBoolean action for --enable-chunked-prefill."""
+        with monkeypatch.context():
+            monkeypatch.setenv("DUMMY_STORE_BOOLEAN_FLAG", env_var)
+
+            parser = FlexibleArgumentParser("testing parser")
+            parser.add_argument("--dummy-store_boolean-flag", action=StoreBoolean)
+            parser = EnvVarArgumentParser(parser=parser)
+            args = parser.parse_args()
+            assert args.dummy_store_boolean_flag == expected
 
     @pytest.mark.parametrize(
         ("env_var", "expected"),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Support consistent parsing of boolean arguments defined in vLLM.

## Description

In vLLM, some args use action='store_true':
https://github.com/vllm-project/vllm/blob/df845b2b46c3e30f5bd3e3be286285ed148323fc/vllm/engine/arg_utils.py#L202-L204
and `--enable-chunked-prefill` has a custom arg parsing action called `StoreBoolean`:
https://github.com/vllm-project/vllm/blob/df845b2b46c3e30f5bd3e3be286285ed148323fc/vllm/engine/arg_utils.py#L561-L568

We want `EnvVarArgumentParser` to treat all of these boolean args consistently. The fix in this PR is to inspect the type of the action in addition to `action.type` to detect when we need to parse a boolean from the env var value.

In my testing, I also learned that `argparse` will parse default string values into the correct type for the argument, so there's no need to have special handling for `int` args (which would also imply special handling of `float`, `_bool_from_string`, `nullable_str`, and other typed args).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by hand for the actual vLLM args and also added unit tests of `EnvVarArgumentParser` for the `'store_true'`, `'store_false'`, and `StoreBoolean` action types for boolean args.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
