### PR TITLE
pyproject: Pin OpenTelemetry versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,10 @@ dependencies = [
   "accelerate==0.33.0",
   "hf-transfer==0.1.8",
   # additional dependencies for OpenTelemetry tracing
-  "opentelemetry-sdk",
-  "opentelemetry-api",
-  "opentelemetry-exporter-otlp",
-  "opentelemetry-semantic-conventions-ai"
+  "opentelemetry-sdk>=1.26.0,<1.27.0",
+  "opentelemetry-api>=1.26.0,<1.27.0",
+  "opentelemetry-exporter-otlp>=1.26.0,<1.27.0",
+  "opentelemetry-semantic-conventions-ai>=0.4.1,<0.5.0"
 ]
 
 [project.urls]


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR pins the major and minor versions of the OpenTelemetry packages to avoid potential issues with version mismatches.
This is a follow-up to https://github.com/vllm-project/vllm/pull/7266


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I build the project `python -m build && pip install dist/*whl` and manually verified that the OTel package versions fall within the pinned range by running `pip list | grep opentelemetry`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
