### PR TITLE
Write to /dev/termination-log on main loop exception

### DIFF
--- a/src/vllm_tgis_adapter/utils.py
+++ b/src/vllm_tgis_adapter/utils.py
@@ -17,4 +17,20 @@ def check_for_failed_tasks(tasks: Iterable[asyncio.Task]) -> None:
         name = task.get_name()
         coro_name = task.get_coro().__name__
 
-        raise RuntimeError(f"task={name} ({coro_name})") from exc
+        raise RuntimeError(f"task={name} ({coro_name}) exception={exc!s}") from exc
+
+
+def write_termination_log(msg: str, file: str = "/dev/termination-log") -> None:
+    """Write to the termination logfile."""
+    # From https://github.com/IBM/text-generation-inference/blob/9388f02d222c0dab695bea1fb595cacdf08d5467/server/text_generation_server/utils/termination.py#L4
+    try:
+        with open(file, "w") as termination_file:
+            termination_file.write(f"{msg}\n")
+    except Exception:
+        # Ignore any errors writing to the termination logfile.
+        # Users can fall back to the stdout logs, and we don't want to pollute
+        # those with an error here.
+        from .logging import init_logger
+
+        logger = init_logger("vllm-tgis-adapter")
+        logger.exception("Unable to write termination logs to %s", file)

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -16,7 +16,7 @@ def test_completions(http_server_url, _servers):
     response = requests.post(
         f"{http_server_url}/v1/completions",
         json={
-            "prompt": "The answer tho life the universe and everything is ",
+            "prompt": "The answer to life the universe and everything is ",
             "model": model_id,
         },
     )

--- a/tests/test_termination_log.py
+++ b/tests/test_termination_log.py
@@ -1,0 +1,38 @@
+import pytest
+
+from .utils import TaskFailedError
+
+
+@pytest.fixture
+def termination_log_fpath(tmp_path, monkeypatch):
+    # create termination log before server starts
+    temp_file = tmp_path / "termination_log.txt"
+    monkeypatch.setenv("TERMINATION_LOG_DIR", str(temp_file))
+    yield temp_file
+    temp_file.unlink(missing_ok=True)
+
+
+@pytest.mark.parametrize(
+    "server_args",
+    [
+        pytest.param(["--enable-lora"], id="enable-lora"),
+        pytest.param(["--max-model-len=10241024"], id="huge-model-len"),
+        pytest.param(["--model=google-bert/bert-base-uncased"], id="unsupported-model"),
+    ],
+    indirect=True,
+)
+def test_startup_fails(request, args, termination_log_fpath, lora_available):
+    """Test that common set-up errors crash the server on startup.
+
+    These errors should be properly reported in the termination log.
+
+    """
+    if lora_available and args.enable_lora:
+        pytest.skip("This test requires a non-lora supported device to run")
+
+    # Server fixture is called explicitly so that we can handle thrown exception
+    with pytest.raises(TaskFailedError):
+        _ = request.getfixturevalue("_servers")
+
+    # read termination logs
+    assert termination_log_fpath.exists()


### PR DESCRIPTION
Addresses https://github.ibm.com/ai-foundation/fmaas-inference-server/issues/722.

## Description

Just like it happens in TGIS https://github.com/IBM/text-generation-inference/blob/9388f02d222c0dab695bea1fb595cacdf08d5467/server/text_generation_server/cli.py#L35, it is useful to have termination logs written to `/dev/termination-log` so that k8s automatically forwards it.

I am not 100% sure this should be brought to vllm-upstream, as I can see them rightfully arguing it should be responsability of the wrapping script, but still I am open to discuss :)


## How Has This Been Tested?
Tested by installing this adapter branch onto a dev pod with vllmv0.5.5 and triggering an injected runtime failure.

Exceptions raising from HTTP server are forwarded just fine to termination logs, but the ones during creation of grpc server currently get overshadowed by a uvicorn one.
Workflow is smt like: grpc server exception awaited-> task cancel sent to all servers -> vllm crashes during exit-coroutine await->exceptions are gathered in `check_for_failed_tasks`->vllm crash only is reported.
Uvicorn stacktrace:

```
INFO 09-04 16:24:09 launcher.py:67] Gracefully stopping http server
INFO:     Shutting down
INFO 09-04 16:24:09 server.py:228] vLLM ZMQ RPC Server was interrupted.
INFO 09-04 16:24:09 multiproc_worker_utils.py:123] Killing local vLLM worker processes
Traceback (most recent call last):
  File "/home/nlucches/work/vllm-tgis-adapter/src/vllm_tgis_adapter/http.py", line 52, in run_http_server
    await shutdown_coro
  File "/home/nlucches/work/vllm-tgis-adapter/.venv/lib/python3.10/site-packages/uvicorn/server.py", line 261, in shutdown
    for server in self.servers:
AttributeError: 'Server' object has no attribute 'servers'. Did you mean: 'serve'?

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/nlucches/.local/share/uv/python/cpython-3.10.14-linux-x86_64-gnu/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/nlucches/.local/share/uv/python/cpython-3.10.14-linux-x86_64-gnu/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/nlucches/work/vllm-tgis-adapter/src/vllm_tgis_adapter/__main__.py", line 98, in <module>
    raise e
  File "/home/nlucches/work/vllm-tgis-adapter/src/vllm_tgis_adapter/__main__.py", line 94, in <module>
    loop.run_until_complete(start_servers(args))
  File "uvloop/loop.pyx", line 1517, in uvloop.loop.Loop.run_until_complete
  File "/home/nlucches/work/vllm-tgis-adapter/src/vllm_tgis_adapter/__main__.py", line 72, in start_servers
    check_for_failed_tasks(tasks)
  File "/home/nlucches/work/vllm-tgis-adapter/src/vllm_tgis_adapter/utils.py", line 27, in check_for_failed_tasks
    raise RuntimeError(f"task={name} ({coro_name}) exception={str(exc)}") from exc
RuntimeError: task=http_server (run_http_server) exception='Server' object has no attribute 'servers'

```
 @joerunde 
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
