### PR TITLE
gha: use vllm v0.6.1 for testing

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,7 +51,8 @@ jobs:
       - name: Install vLLM build deps
         run: |
           sudo apt update
-          sudo apt install --no-install-recommends -y libnuma-dev
+          sudo apt install --no-install-recommends -y \
+            libnuma-dev libdnnl-dev opencl-dev
 
       - name: Set up Python ${{ matrix.pyv }}
         uses: actions/setup-python@v5

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,7 +32,7 @@ jobs:
         pyv: ["3.11"]
         vllm_version:
           # - "" # skip the pypi version as it will not work on CPU
-          - "git+https://github.com/vllm-project/vllm@v0.5.5"
+          - "git+https://github.com/vllm-project/vllm@v0.6.1"
           - "git+https://github.com/vllm-project/vllm@main"
           - "git+https://github.com/opendatahub-io/vllm@main"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,13 +32,13 @@ if TYPE_CHECKING:
     ArgFixture = Annotated[T, pytest.fixture]
 
 
-@pytest.fixture()
+@pytest.fixture
 def lora_available() -> bool:
     # lora does not work on cpu
     return not vllm.config.is_cpu()
 
 
-@pytest.fixture()
+@pytest.fixture
 def lora_adapter_name(request: pytest.FixtureRequest) -> str:
     if not request.getfixturevalue("lora_available"):
         pytest.skip("Lora is not available with this configuration")
@@ -46,7 +46,7 @@ def lora_adapter_name(request: pytest.FixtureRequest) -> str:
     return "lora-test"
 
 
-@pytest.fixture()
+@pytest.fixture
 def lora_adapter_path(request: pytest.FixtureRequest) -> str:
     if not request.getfixturevalue("lora_available"):
         pytest.skip("Lora is not available with this configuration")
@@ -68,7 +68,7 @@ def disable_frontend_multiprocessing(request):
     return request.param
 
 
-@pytest.fixture()
+@pytest.fixture
 def args(  # noqa: PLR0913
     request: pytest.FixtureRequest,
     monkeypatch,
@@ -109,31 +109,31 @@ def args(  # noqa: PLR0913
     return args
 
 
-@pytest.fixture()
+@pytest.fixture
 def grpc_server_port() -> int:
     """Port for the grpc server."""
     return get_random_port()
 
 
-@pytest.fixture()
+@pytest.fixture
 def grpc_server_address(grpc_server_port: ArgFixture[int]) -> str:
     """Address for the grpc server."""
     return f"localhost:{grpc_server_port}"
 
 
-@pytest.fixture()
+@pytest.fixture
 def http_server_port() -> int:
     """Port for the http server."""
     return get_random_port()
 
 
-@pytest.fixture()
+@pytest.fixture
 def http_server_url(http_server_port: ArgFixture[int]) -> str:
     """Url for the http server."""
     return f"http://localhost:{http_server_port}"
 
 
-@pytest.fixture()
+@pytest.fixture
 def _servers(
     args: ArgFixture[argparse.Namespace],
     grpc_server_address: ArgFixture[str],

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -3,7 +3,7 @@ import pytest
 from .utils import GrpcClient
 
 
-@pytest.fixture()
+@pytest.fixture
 def grpc_client(grpc_server_address, _servers):
     """Return a grpc client connected to the grpc server."""
     host, port = grpc_server_address.split(":")


### PR DESCRIPTION
- use vLLM v0.6.1 tag
- fix linter complaints
- add missing oneDNN build dependency (https://github.com/vllm-project/vllm/pull/7257)
- add missing openCL dependency