### PR TITLE
grpc_server: use x-correlation-id as request-id when possible

### DIFF
--- a/src/vllm_tgis_adapter/grpc/grpc_server.py
+++ b/src/vllm_tgis_adapter/grpc/grpc_server.py
@@ -518,8 +518,17 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
         return response
 
     @staticmethod
-    def request_id(context: ServicerContext) -> str:  # noqa:  ARG004
-        return uuid.uuid4().hex
+    def request_id(context: ServicerContext) -> str:
+        metadata = context.invocation_metadata()
+        if not metadata:
+            return uuid.uuid4().hex
+
+        correlation_id = dict(metadata).get("x-correlation-id")
+
+        if not correlation_id:
+            return uuid.uuid4().hex
+
+        return correlation_id
 
     async def _validate_and_convert_params(
         self,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -126,6 +126,7 @@ class GrpcClient:
         model_id: str | None = None,
         max_new_tokens: int = 10,
         adapter_id: str | None = None,
+        metadata: list[tuple[str, str]] | None = None,
     ) -> GenerationResponse | Sequence[GenerationResponse]:
         # assert model_id  # FIXME: is model_id required?
 
@@ -143,6 +144,7 @@ class GrpcClient:
 
         response = self.generation_service_stub.Generate(
             request=request,
+            metadata=metadata,
         )
 
         if single_request:


### PR DESCRIPTION
> Currently, the vLLM OpenTelemetry span exports the request_id, but inspecting the WatsonX trace in Instana can be confusing due to the presence of multiple IDs.
Using the x-correlation-id as the request_id would help make the trace more coherent.

https://issues.redhat.com/browse/RHOAIENG-12927