### PR TITLE
http_server: compatibility fixes for vllm>0.6.1.post1

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        pyv: ["3.11"]
+        pyv: ["3.12"]
         vllm_version:
           # - "" # skip the pypi version as it will not work on CPU
           - "git+https://github.com/vllm-project/vllm@v0.6.1.post2"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,7 +32,7 @@ jobs:
         pyv: ["3.11"]
         vllm_version:
           # - "" # skip the pypi version as it will not work on CPU
-          - "git+https://github.com/vllm-project/vllm@v0.6.1"
+          - "git+https://github.com/vllm-project/vllm@v0.6.1.post2"
           - "git+https://github.com/vllm-project/vllm@main"
           - "git+https://github.com/opendatahub-io/vllm@main"
 

--- a/src/vllm_tgis_adapter/http.py
+++ b/src/vllm_tgis_adapter/http.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from vllm.entrypoints.launcher import serve_http
-from vllm.entrypoints.openai.api_server import (
-    init_app,
-)
+from vllm.entrypoints.openai.api_server import build_app
 from vllm.logger import init_logger
+
+try:
+    from vllm.entrypoints.openai.api_server import init_app
+except ImportError:  # vllm > 0.6.1.post2
+    from vllm.entrypoints.openai.api_server import init_app_state
+
 
 if TYPE_CHECKING:
     import argparse
@@ -27,7 +31,12 @@ async def run_http_server(
     # modified copy of vllm.entrypoints.openai.api_server.run_server that
     # allows passing of the engine
 
-    app = await init_app(engine, args)  # type: ignore[arg-type]
+    try:
+        app = await init_app(engine, args)  # type: ignore[arg-type]
+    except NameError:  # vllm > 0.6.1.post2
+        app = build_app(args)
+        model_config = await engine.get_model_config()
+        init_app_state(engine, model_config, app.state, args)
 
     serve_kwargs = {
         "host": args.host,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 @pytest.fixture
 def lora_available() -> bool:
     # lora does not work on cpu
-    return not vllm.config.is_cpu()
+    return not vllm.config.current_platform.is_cpu()
 
 
 @pytest.fixture


### PR DESCRIPTION
- https://github.com/vllm-project/vllm/pull/8492 renamed `init_app` to `init_app_state`
- gha: bump vllm tag to `v0.6.1.post2`

https://issues.redhat.com/browse/RHOAIENG-12997