### PR TITLE
Exploit vLLM options to return deltas/final-output only

### DIFF
--- a/src/vllm_tgis_adapter/utils.py
+++ b/src/vllm_tgis_adapter/utils.py
@@ -1,5 +1,5 @@
 import asyncio
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 
 
 def check_for_failed_tasks(tasks: Iterable[asyncio.Task]) -> None:
@@ -34,3 +34,7 @@ def write_termination_log(msg: str, file: str = "/dev/termination-log") -> None:
 
         logger = init_logger("vllm-tgis-adapter")
         logger.exception("Unable to write termination logs to %s", file)
+
+
+def to_list(seq: Sequence[int]) -> list[int]:
+    return seq if isinstance(seq, list) else list(seq)


### PR DESCRIPTION
Nontrivial performance benefit, particularly when running with decoupled front-end process.

These changes require vLLM >= `0.6.1.post2`