### PR TITLE
Fix calls to defunct AsyncEngineClient

### DIFF
--- a/src/vllm_tgis_adapter/grpc/grpc_server.py
+++ b/src/vllm_tgis_adapter/grpc/grpc_server.py
@@ -262,7 +262,7 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
                 log_tracing_disabled_warning()
             generators.append(
                 self.engine.generate(
-                    inputs,
+                    inputs=inputs,
                     sampling_params=sampling_params,
                     request_id=f"{request_id}-{i}",
                     **adapter_kwargs,
@@ -363,7 +363,7 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
         result_generator = self.engine.generate(
             # prompt is supplied for observability, the text is not
             # re-tokenized when `prompt_token_ids` is supplied
-            inputs,
+            inputs=inputs,
             sampling_params=sampling_params,
             request_id=request_id,
             **adapter_kwargs,


### PR DESCRIPTION
Address breaking changes in upstream main (v0.6.2?) https://github.com/vllm-project/vllm/pull/8673 and https://github.com/vllm-project/vllm/pull/8157. The latter is yet another bulky change to the rpc client-server interaction: I couldn't spot differences in functionality and tests are fine on our side, but I could really use some help to double check that what's been implemented upstream is still fully compatible with the use being made of here.

I branched off https://github.com/opendatahub-io/vllm-tgis-adapter/pull/136, so we should be merging that PR first.
