### PR TITLE
fix: add_special_tokens in tokenize

### DIFF
--- a/src/vllm_tgis_adapter/grpc/grpc_server.py
+++ b/src/vllm_tgis_adapter/grpc/grpc_server.py
@@ -855,7 +855,9 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
         # other threads
         for req in request.requests:
             batch_encoding = tokenizer.encode_plus(
-                text=req.text, return_offsets_mapping=request.return_offsets
+                text=req.text,
+                return_offsets_mapping=request.return_offsets,
+                add_special_tokens=ADD_SPECIAL_TOKENS,
             )
 
             # Tokenize the input text

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -26,17 +26,11 @@ def test_generation_request(grpc_client):
 
 
 def test_tokenize_request(grpc_client):
-    response_generate = grpc_client.make_request(
-        text="Please answer the following question.\nhow far is Paris from New York?",
-        max_new_tokens=50,
-        model_id="facebook/opt-125m",
-    )
     response_tokenize = grpc_client.make_request_tokenize(
         text="Please answer the following question.\nhow far is Paris from New York?",
-        model_id="facebook/opt-125m",
     )
 
-    assert response_tokenize.token_count == response_generate.generated_token_count
+    assert response_tokenize.token_count
 
 
 def test_generation_request_stream(grpc_client):

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -25,6 +25,22 @@ def test_generation_request(grpc_client):
     assert response.stop_reason is not None
 
 
+def test_tokenize_request(grpc_client):
+    response_generate = grpc_client.make_request(
+        "The answer to life the universe and everything is "
+    )
+    response_tokenize = grpc_client.make_request_tokenize(
+        "The answer to life the universe and everything is "
+    )
+
+    assert response_tokenize.text
+    assert (
+        response_tokenize.generated_token_count
+        == response_generate.generated_token_count
+    )
+    assert response_tokenize.stop_reason is not None
+
+
 def test_generation_request_stream(grpc_client):
     streaming_response = grpc_client.make_request_stream(
         "The answer to life the universe and everything is ",

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -27,18 +27,13 @@ def test_generation_request(grpc_client):
 
 def test_tokenize_request(grpc_client):
     response_generate = grpc_client.make_request(
-        "The answer to life the universe and everything is "
+        "Please answer the following question.\nhow far is Paris from New York?"
     )
     response_tokenize = grpc_client.make_request_tokenize(
-        "The answer to life the universe and everything is "
+        "Please answer the following question.\nhow far is Paris from New York?"
     )
 
-    assert response_tokenize.text
-    assert (
-        response_tokenize.generated_token_count
-        == response_generate.generated_token_count
-    )
-    assert response_tokenize.stop_reason is not None
+    assert response_tokenize.token_count == response_generate.generated_token_count
 
 
 def test_generation_request_stream(grpc_client):

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -27,7 +27,8 @@ def test_generation_request(grpc_client):
 
 def test_tokenize_request(grpc_client):
     response_generate = grpc_client.make_request(
-        "Please answer the following question.\nhow far is Paris from New York?"
+        "Please answer the following question.\nhow far is Paris from New York?",
+        max_new_tokens=50,
     )
     response_tokenize = grpc_client.make_request_tokenize(
         "Please answer the following question.\nhow far is Paris from New York?"

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -27,11 +27,13 @@ def test_generation_request(grpc_client):
 
 def test_tokenize_request(grpc_client):
     response_generate = grpc_client.make_request(
-        "Please answer the following question.\nhow far is Paris from New York?",
+        text="Please answer the following question.\nhow far is Paris from New York?",
         max_new_tokens=50,
+        model_id="facebook/opt-125m",
     )
     response_tokenize = grpc_client.make_request_tokenize(
-        "Please answer the following question.\nhow far is Paris from New York?"
+        text="Please answer the following question.\nhow far is Paris from New York?",
+        model_id="facebook/opt-125m",
     )
 
     assert response_tokenize.token_count == response_generate.generated_token_count

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,11 +13,11 @@ from vllm_tgis_adapter.grpc.pb.generation_pb2 import (
     BatchedGenerationRequest,
     BatchedTokenizeRequest,
     GenerationRequest,
-    TokenizeRequest,
     ModelInfoRequest,
     Parameters,
     SingleGenerationRequest,
     StoppingCriteria,
+    TokenizeRequest,
 )
 from vllm_tgis_adapter.grpc.pb.generation_pb2_grpc import GenerationServiceStub
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,6 +13,7 @@ from vllm_tgis_adapter.grpc.pb.generation_pb2 import (
     BatchedGenerationRequest,
     BatchedTokenizeRequest,
     GenerationRequest,
+    TokenizeRequest,
     ModelInfoRequest,
     Parameters,
     SingleGenerationRequest,
@@ -186,7 +187,7 @@ class GrpcClient:
 
         request = BatchedTokenizeRequest(
             model_id=model_id,
-            requests=[GenerationRequest(text=piece) for piece in text],
+            requests=[TokenizeRequest(text=piece) for piece in text],
             adapter_id=adapter_id,
         )
 


### PR DESCRIPTION
#66 made `add_special_tokens` true by default but its behaviour isn't replicated in /tokenize resulting in a different token count if `ADD_SPECIAL_TOKENS` is false. This PR fixes that by passing it in /tokenize and adds a test for the tokenize method. 

I can follow this up with another test that compares the token count between the methods if required but otherwise this closes #141.