### PR TITLE
🐛 handle MistralTokenizer special case

### DIFF
--- a/src/vllm_tgis_adapter/grpc/grpc_server.py
+++ b/src/vllm_tgis_adapter/grpc/grpc_server.py
@@ -886,18 +886,17 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
 
             if request.return_offsets:
                 if is_mistral_tokenizer:
-                    logger.warning(
+                    raise ValueError(
                         "Mistral tokenizer doesn't support "
                         "return_offsets at the moment. "
                     )
-                else:
-                    offsets = [
-                        {"start": start, "end": end}
-                        for start, end in batch_encoding.offset_mapping
-                        if start is not None and end is not None
-                    ]
-                    # Truncate offset list if request.truncate_input_tokens
-                    offsets = offsets[-token_count:]
+                offsets = [
+                    {"start": start, "end": end}
+                    for start, end in batch_encoding.offset_mapping
+                    if start is not None and end is not None
+                ]
+                # Truncate offset list if request.truncate_input_tokens
+                offsets = offsets[-token_count:]
 
             tokens = tokens[-token_count:] if request.return_tokens else None
 

--- a/src/vllm_tgis_adapter/grpc/grpc_server.py
+++ b/src/vllm_tgis_adapter/grpc/grpc_server.py
@@ -863,7 +863,7 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
                 if request.return_offsets:
                     raise ValueError(
                         f"{type(tokenizer)} doesn't support "
-                        "return_offsets at the moment. "
+                        "the return_offsets option"
                     )
                 token_ids = tokenizer.encode(
                     prompt=req.text,

--- a/src/vllm_tgis_adapter/tgis_utils/guided_decoding.py
+++ b/src/vllm_tgis_adapter/tgis_utils/guided_decoding.py
@@ -4,7 +4,6 @@ import asyncio
 import concurrent.futures
 from re import escape as regex_escape
 
-from transformers import PreTrainedTokenizer
 from vllm.model_executor.guided_decoding import outlines_decoding
 from vllm.model_executor.guided_decoding.outlines_decoding import (
     GuidedDecodingMode,
@@ -16,12 +15,13 @@ from vllm.model_executor.guided_decoding.outlines_logits_processors import (
     JSONLogitsProcessor,
     RegexLogitsProcessor,
 )
+from vllm.transformers_utils.tokenizer import AnyTokenizer
 
 from vllm_tgis_adapter.grpc.pb.generation_pb2 import DecodingParameters
 
 
 async def get_outlines_guided_decoding_logits_processor(
-    decoding_params: DecodingParameters, tokenizer: PreTrainedTokenizer
+    decoding_params: DecodingParameters, tokenizer: AnyTokenizer
 ) -> JSONLogitsProcessor | RegexLogitsProcessor | None:
     """Check for guided decoding parameters.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Right now, [MistralTokenizer](https://github.com/vllm-project/vllm/blob/v0.6.2/vllm/transformers_utils/tokenizers/mistral.py#L43) doesn't support the `encode_plus` option. We use the `encode` option for now, and throw an error to the user if `return_offset` is requested.

Also, `mistral` models do NOT select `mistral` as the tokenizer by default. `TOKENIZER_MODE=mistral` has to be set in order to do that.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
