### PR TITLE
Allow greedy decoding with 0.0 temperature

### DIFF
--- a/src/vllm_tgis_adapter/grpc/grpc_server.py
+++ b/src/vllm_tgis_adapter/grpc/grpc_server.py
@@ -630,11 +630,13 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
         )
 
         random_sampling_params: dict[str, Any]
-        if greedy:
+        temperature = sampling.temperature if sampling.HasField("temperature") else 1.0
+        if greedy or temperature == 0.0:
+            # 0.0 temperature is equivalent to greedy decoding
             random_sampling_params = {"temperature": 0.0}
         else:
             random_sampling_params = {
-                "temperature": with_default(sampling.temperature, 1.0),
+                "temperature": temperature,
                 "top_k": with_default(sampling.top_k, -1),
                 "top_p": with_default(sampling.top_p, 1.0),
                 "seed": sampling.seed if sampling.HasField("seed") else None,

--- a/src/vllm_tgis_adapter/grpc/pb/generation.proto
+++ b/src/vllm_tgis_adapter/grpc/pb/generation.proto
@@ -132,8 +132,9 @@ message DecodingParameters {
 
 
 message SamplingParameters {
-  // Default (0.0) means disabled (equivalent to 1.0)
-  float temperature = 1;
+  // Unset will default to 1.0
+  // 0.0 is equivalent to greedy decoding
+  optional float temperature = 1;
   // Default (0) means disabled
   uint32 top_k = 2;
   // Default (0) means disabled (equivalent to 1.0)

--- a/src/vllm_tgis_adapter/grpc/validation.py
+++ b/src/vllm_tgis_adapter/grpc/validation.py
@@ -22,7 +22,6 @@ class TGISValidationError(str, Enum):
     https://github.ibm.com/ai-foundation/fmaas-inference-server/blob/main/router/src/validation.rs#L238-L271
     """
 
-    Temperature = "temperature must be >= 0.05"
     TopP = "top_p must be > 0.0 and <= 1.0"
     TopK = "top_k must be strictly positive"
     TypicalP = "typical_p must be <= 1.0"
@@ -139,8 +138,6 @@ def validate_params(  # noqa: C901
         )
     ):
         TGISValidationError.SampleParametersGreedy.error()
-    if sampling.temperature and sampling.temperature < 0.05:
-        TGISValidationError.Temperature.error()
     if sampling.top_k < 0:
         TGISValidationError.TopK.error()
     if not (0 <= sampling.top_p <= 1):


### PR DESCRIPTION
## Description
This PR adds the `optional` tag to the `temperature` field so that we can test presence in the server, and use greedy decoding if a user passes 0.0 temperature. This is to reduce confusion with the OpenAI api, which doesn't have a sampling/greedy flag and just uses zero temperature to enable greedy decoding.

As is, users will see an error about the temperature being too low if they pass in a temperature in the range (0, 0.05), but if they send in exactly 0, we instead default back to 1. This causes users to open bug reports about greedy mode returning random results. This PR also removes the low temperature check, since I think it would be confusing to disallow low temperatures but explicitly allow zero.


## How Has This Been Tested?
I ran a server with vllm-tgis-adapter@main installed, and booted up one `grpcui` instance so that it would pick up the old protobuf definition. I then stopped the server, installed vllm-tgis-adapter@zero-temperature-support, booted the server again, and started a second `grpcui` instance so it would pick up the new protobuf definition. I verified that both:
- Unset temperature and temperature==0 requests with the old protobuf defs returned random results
- Unset temperature requests with the new protobuf defs returned random results
- Temperatue==0 requests with the new protobuf defs returned greedy results


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
