### PR TITLE
Updates for vllm v0.6.4

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,7 +32,7 @@ jobs:
         pyv: ["3.12"]
         vllm_version:
           # - "" # skip the pypi version as it will not work on CPU
-          - "git+https://github.com/vllm-project/vllm@v0.6.2"
+          - "git+https://github.com/vllm-project/vllm@v0.6.4"
           - "git+https://github.com/vllm-project/vllm@main"
           - "git+https://github.com/opendatahub-io/vllm@main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 requires-python = ">=3.9"
 dynamic = ["version"]
 dependencies = [
-  "vllm>=0.6.2",
+  "vllm>=0.6.4",
   "prometheus_client==0.21.0",
   "grpcio==1.67.0",
   "grpcio-health-checking==1.62.2",

--- a/src/vllm_tgis_adapter/grpc/grpc_server.py
+++ b/src/vllm_tgis_adapter/grpc/grpc_server.py
@@ -16,7 +16,7 @@ from grpc_reflection.v1alpha import reflection
 from vllm.engine.async_llm_engine import AsyncLLMEngine
 from vllm.engine.multiprocessing import MQEngineDeadError
 from vllm.entrypoints.openai.serving_completion import merge_async_iterators
-from vllm.inputs import LLMInputs
+from vllm.inputs import token_inputs
 from vllm.sampling_params import RequestOutputKind, SamplingParams
 from vllm.tracing import (
     contains_trace_headers,
@@ -257,7 +257,7 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
                 sampling_params, truncate_input_tokens, req.text, tokenizer, context
             )
 
-            inputs = LLMInputs(
+            inputs = token_inputs(
                 prompt=req.text,
                 prompt_token_ids=input_ids,
             )
@@ -356,7 +356,7 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
             context,
         )
 
-        inputs = LLMInputs(
+        inputs = token_inputs(
             prompt=request.request.text,
             prompt_token_ids=input_ids,
         )


### PR DESCRIPTION
[vLLM v0.6.4 has been released](https://github.com/vllm-project/vllm/releases/tag/v0.6.4). This PR is to make changes to the adapter to support this new release.

TODO: I only noticed this one change and wanted to make a commit out of it. More testing should be done to see if additional changes are needed.

## Description
<!--- Describe your changes in detail -->
- remove use of deprecated `LLMInputs` that is now just a type instead of a class [REF](https://github.com/vllm-project/vllm/pull/8688)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested by running the changed code with vLLM v0.6.4 installed.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
