### PR TITLE
:loud_sound: overhaul logging on engine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   "grpcio-reflection==1.62.2",
   "accelerate==0.34.2",
   "hf-transfer==0.1.8",
+  "cachetools~=5.5",
   # additional dependencies for OpenTelemetry tracing
   "opentelemetry-sdk>=1.26.0,<1.28.0",
   "opentelemetry-api>=1.26.0,<1.28.0",

--- a/src/vllm_tgis_adapter/__main__.py
+++ b/src/vllm_tgis_adapter/__main__.py
@@ -15,6 +15,8 @@ from vllm.entrypoints.openai.api_server import (
 from vllm.entrypoints.openai.cli_args import make_arg_parser
 from vllm.utils import FlexibleArgumentParser
 
+from vllm_tgis_adapter.tgis_utils.logs import add_logging_wrappers
+
 from .grpc import run_grpc_server
 from .http import run_http_server
 from .logging import init_logger
@@ -32,6 +34,8 @@ async def start_servers(args: argparse.Namespace) -> None:
 
     tasks: list[asyncio.Task] = []
     async with build_async_engine_client(args) as engine:
+        add_logging_wrappers(engine)
+
         http_server_task = loop.create_task(
             run_http_server(args, engine),
             name="http_server",

--- a/src/vllm_tgis_adapter/grpc/grpc_server.py
+++ b/src/vllm_tgis_adapter/grpc/grpc_server.py
@@ -248,7 +248,7 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
             )
             is_tracing_enabled = await self.engine.is_tracing_enabled()
             headers = dict(context.invocation_metadata())
-            logs.set_correlation_id(request_id_i, headers["x-correlation_id"])
+            logs.set_correlation_id(request_id_i, headers.get("x-correlation_id"))
             if is_tracing_enabled:
                 kwargs["trace_headers"] = extract_trace_headers(headers)
             elif contains_trace_headers(headers):
@@ -345,7 +345,7 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
         elif contains_trace_headers(headers):
             log_tracing_disabled_warning()
         if "x-correlation-id" in headers:
-            logs.set_correlation_id(request_id, headers["x-correlation_id"])
+            logs.set_correlation_id(request_id, headers.get("x-correlation_id"))
 
         result_generator = self.engine.generate(
             # prompt is supplied for observability, the text is not

--- a/src/vllm_tgis_adapter/tgis_utils/logs.py
+++ b/src/vllm_tgis_adapter/tgis_utils/logs.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 
     from vllm import PromptType, RequestOutput, SamplingParams
     from vllm.engine.protocol import EngineClient
+    from vllm.sequence import RequestMetrics
 
 logger = init_logger(__name__)
 
@@ -97,7 +98,7 @@ def add_logging_wrappers(engine: EngineClient) -> None:
         if last:
             # Log the response
             with suppress(BaseException):
-                _new_log_response(
+                _log_response(
                     request_id=request_id,
                     correlation_id=correlation_id,
                     response=last,
@@ -106,10 +107,6 @@ def add_logging_wrappers(engine: EngineClient) -> None:
                 )
 
     engine.generate = generate_with_logging
-
-
-if TYPE_CHECKING:
-    from vllm.sequence import RequestMetrics
 
 
 def _log_error(request_id: str, correlation_id: str, exception_str: str) -> None:
@@ -143,7 +140,7 @@ def _log_request(
     )
 
 
-def _new_log_response(
+def _log_response(
     request_id: str,
     correlation_id: str,
     response: RequestOutput,

--- a/src/vllm_tgis_adapter/tgis_utils/logs.py
+++ b/src/vllm_tgis_adapter/tgis_utils/logs.py
@@ -2,172 +2,199 @@
 
 from __future__ import annotations
 
+import functools
 import logging
+import time
+from contextlib import suppress
 from typing import TYPE_CHECKING
 
-from google.protobuf import text_format
+import cachetools
 
-from vllm_tgis_adapter.grpc.pb.generation_pb2 import (
-    BatchedGenerationRequest,
-    StopReason,
-)
+from vllm_tgis_adapter.logging import init_logger
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from vllm import PromptType, RequestOutput, SamplingParams
+    from vllm.engine.protocol import EngineClient
+
+logger = init_logger(__name__)
+
+# Blackboard for storing correlation ids when they come into the servers, so
+# that they can be added to log messages here.
+# TTLCache with a max size is used to make sure everything is cleaned up and we
+# don't leak memory.
+_REQUEST_ID_TO_CORRELATION_ID = cachetools.TTLCache(maxsize=2048, ttl=600)
+
+
+def set_correlation_id(request_id: str, correlation_id: str) -> None:
+    _REQUEST_ID_TO_CORRELATION_ID[request_id] = correlation_id
+
+
+def get_correlation_id(request_id: str) -> str | None:
+    correlation_id = _REQUEST_ID_TO_CORRELATION_ID.get(request_id)
+    if not correlation_id:
+        # http server will format the request id like:
+        # {method_str}-{base_request_id}-{batch_index}
+        # So we can try stripping off leading and trailing `-` clauses
+        request_id = "-".join(request_id.split("-")[1:-1])
+        correlation_id = _REQUEST_ID_TO_CORRELATION_ID.get(request_id)
+    return correlation_id
+
+
+def add_logging_wrappers(engine: EngineClient) -> None:
+    """Inject request, response, and error logs into the engine.
+
+    We log this way so that all entrypoints are logged consistently, whether the
+    original request is from the grpc server or the http server, and regardless
+    of which endpoint is actually used.
+    """
+    old_generate_fn = engine.generate
+
+    @functools.wraps(old_generate_fn)
+    async def generate_with_logging(*args, **kwargs) -> AsyncGenerator[RequestOutput]:  # noqa: ANN003 ANN002
+        start_time = time.time()
+
+        # NB: coupled to EngineClient.generate() api
+        prompt = _get_arg("prompt", 0, *args, **kwargs)
+        sampling_params = _get_arg("sampling_params", 1, *args, **kwargs)
+        request_id = _get_arg("request_id", 2, *args, **kwargs)
+        lora_request = _get_arg("lora_request", 3, *args, **kwargs)
+        prompt_adapter_request = _get_arg("prompt_adapter_request", 5, *args, **kwargs)
+
+        correlation_id = get_correlation_id(request_id=request_id)
+        adapter_id = None
+        if lora_request:
+            adapter_id = lora_request.adapter_id
+        elif prompt_adapter_request:
+            adapter_id = prompt_adapter_request.prompt_adapter_id
+
+        # Log the request
+        with suppress(BaseException):
+            _log_request(
+                prompt=prompt,
+                params=sampling_params,
+                request_id=request_id,
+                correlation_id=correlation_id,
+                adapter_id=adapter_id,
+            )
+
+        # Run the generate method
+        last = None
+        try:
+            async for response in old_generate_fn(*args, **kwargs):
+                last = response
+                yield response
+        except BaseException as e:
+            # Log any error
+            _log_error(
+                request_id=request_id,
+                correlation_id=correlation_id,
+                exception_str=str(e),
+            )
+            raise
+
+        if last:
+            # Log the response
+            with suppress(BaseException):
+                _new_log_response(
+                    request_id=request_id,
+                    correlation_id=correlation_id,
+                    response=last,
+                    engine_metrics=last.metrics,
+                    start_time=start_time,
+                )
+
+    engine.generate = generate_with_logging
+
 
 if TYPE_CHECKING:
     from vllm.sequence import RequestMetrics
 
-    from vllm_tgis_adapter.grpc.pb.generation_pb2 import (
-        GenerationResponse,
-        Parameters,
-        SingleGenerationRequest,
+
+def _log_error(request_id: str, correlation_id: str, exception_str: str) -> None:
+    logger.error(
+        "Request failed: request_id=%s correlation_id=%s error=%s",
+        request_id,
+        correlation_id,
+        exception_str,
     )
 
 
-def log_response(  # noqa: PLR0913
-    request: BatchedGenerationRequest | SingleGenerationRequest,
-    response: GenerationResponse,
-    engine_metrics: RequestMetrics | None,
-    start_time: float,
-    logger: logging.Logger,
-    headers: dict,
-    sub_request_num: int = 0,
-) -> None:
-    if isinstance(request, BatchedGenerationRequest):
-        # unary case
-        request_count = len(request.requests)
-        kind_log = (
-            "Request"
-            if request_count == 1
-            else f"Sub-request {sub_request_num} from batch of {request_count}"
-        )
-        inputs = [r.text for r in request.requests]
-        method_str = "generate"
-    else:
-        # streaming case
-        inputs = [request.request.text]
-        kind_log = "Streaming response"
-        method_str = "generate_stream"
-
-    _log_response(
-        inputs=inputs,
-        response=response,
-        params=request.params,
-        prefix_id=request.prefix_id,
-        adapter_id=request.adapter_id,
-        engine_metrics=engine_metrics,
-        start_time=start_time,
-        kind_log=kind_log,
-        method_str=method_str,
-        logger=logger,
-        headers=headers,
-    )
-
-
-def log_error(
-    request: BatchedGenerationRequest | SingleGenerationRequest,
-    exception_str: str,
-    logger: logging.Logger,
-) -> None:
-    """Log errors similar to how the TGIS server does."""
-    # NB: We don't actually log the `Exception` here to match the TGIS behavior
-    # of just logging the simple string representation of the error
-    param_str = text_format.MessageToString(request.params, as_one_line=True)
-    prefix_id = request.prefix_id
-    adapter_id = request.adapter_id
-
-    if isinstance(request, BatchedGenerationRequest):
-        method_str = "generate"
-        inputs = [r.text for r in request.requests]
-    else:
-        method_str = "generate_stream"
-        inputs = [request.request.text]
-
-    short_input = [_truncate(input_, 32) for input_ in inputs]
-    input_chars = sum(len(input_) for input_ in inputs)
-
-    span_str = (
-        f"{method_str}{{input={short_input} prefix_id={prefix_id} "
-        f"adapter_id={adapter_id} input_chars=[{input_chars}] "
-        f"params={param_str}"
-    )
-
-    logger.error("%s: %s", span_str, exception_str)
-
-
-def _log_response(  # noqa: PLR0913
-    inputs: list[str],
-    params: Parameters,
-    prefix_id: str,
+def _log_request(
+    request_id: str,
+    params: SamplingParams,
     adapter_id: str,
-    response: GenerationResponse,
+    correlation_id: str,
+    prompt: PromptType,
+) -> None:
+    if isinstance(prompt, dict) and "prompt_token_ids" in prompt:
+        input_tokens = f" input_tokens={len(prompt['prompt_token_ids'])},"
+    else:
+        input_tokens = ""
+    logger.info(
+        "Processing request: {request_id=%s, correlation_id=%s, adapter_id=%s, "
+        "%sparams=%s}",
+        request_id,
+        correlation_id,
+        adapter_id,
+        input_tokens,
+        params,
+    )
+
+
+def _new_log_response(
+    request_id: str,
+    correlation_id: str,
+    response: RequestOutput,
     engine_metrics: RequestMetrics | None,
     start_time: float,
-    kind_log: str,
-    method_str: str,
-    logger: logging.Logger,
-    headers: dict,
 ) -> None:
     """Log responses similar to how the TGIS server does."""
-    # This time contains both request validation and tokenization
+    if len(response.outputs) == 0:
+        # Nothing to log about
+        return
+
+    generated_tokens = len(response.outputs[0].token_ids)
     if engine_metrics is None:
         logger.warning("No engine metrics for request, cannot log timing info")
-        tokenization_time = inference_time = queue_time = time_per_token = (
-            total_time
-        ) = 0.0
+        inference_time = queue_time = time_per_token = total_time = 0.0
     else:
         assert engine_metrics is not None
         assert engine_metrics.first_scheduled_time is not None
 
-        tokenization_time = engine_metrics.arrival_time - start_time
         inference_time = (
             engine_metrics.last_token_time - engine_metrics.first_scheduled_time
         )
         assert engine_metrics.time_in_queue is not None
         queue_time = engine_metrics.time_in_queue
 
-        time_per_token = _safe_div(inference_time, response.generated_token_count)
+        time_per_token = _safe_div(inference_time, generated_tokens)
         total_time = engine_metrics.last_token_time - start_time
-    output_len = len(response.text)
-    short_output = _truncate(response.text, 32)
-    short_input = [_truncate(input_, 32) for input_ in inputs]
-    input_chars = sum(len(input_) for input_ in inputs)
+    output_len = len(response.outputs[0].text)
 
-    paramstr = text_format.MessageToString(params, as_one_line=True)
-    span_str = (
-        f"{method_str}{{input={short_input} prefix_id={prefix_id} "
-        f"correlation_id={headers.get('x-correlation-id')} "
-        f"adapter_id={adapter_id} "
-        f"input_chars=[{input_chars}] params={paramstr} "
-        f"tokenization_time={tokenization_time * 1e3:.2f}ms "
-        f"queue_time={queue_time * 1e3:.2f}ms "
-        f"inference_time={inference_time * 1e3:.2f}ms "
-        f"time_per_token={time_per_token * 1e3:.2f}ms "
-        f"total_time={total_time * 1e3:.2f}ms "
-        f"input_toks={response.input_token_count}}}"
-    )
-    stop_reason_str = StopReason.Name(response.stop_reason)
+    stop_reason_str = response.outputs[0].finish_reason
 
-    if response.stop_reason == StopReason.ERROR:
-        level = logging.ERROR
-    elif response.stop_reason in {StopReason.CANCELLED, StopReason.TOKEN_LIMIT}:
+    if stop_reason_str == "abort":
         level = logging.WARNING
     else:
         level = logging.INFO
     logger.log(
         level,
-        "%s: %s generated %d tokens before %s, output %d chars: %s",
-        span_str,
-        kind_log,
-        response.generated_token_count,
+        "Finished processing request: {request_id=%s, correlation_id=%s}. "
+        "Timing info: {queue_time=%.2fms, inference_time=%.2fms, "
+        "time_per_token=%.2fms, total_time=%.2fms}. "
+        "Generated %d tokens before finish reason: %s, output %d chars",
+        request_id,
+        correlation_id,
+        queue_time * 1e3,
+        inference_time * 1e3,
+        time_per_token * 1e3,
+        total_time * 1e3,
+        generated_tokens,
         stop_reason_str,
         output_len,
-        short_output,
     )
-
-
-def _truncate(text: str, len_: int) -> bytes:
-    """Truncate a string and escape control characters."""
-    text = f"{text:.{len_}}..." if len(text) > len_ else text
-    return text.encode("unicode_escape")
 
 
 def _safe_div(a: float, b: float, *, default: float = 0.0) -> float:
@@ -176,3 +203,12 @@ def _safe_div(a: float, b: float, *, default: float = 0.0) -> float:
         return a / b
     except ZeroDivisionError:
         return default
+
+
+def _get_arg(name: str, pos: int, *args, **kwargs) -> object:  # noqa: ANN003 ANN002
+    """Get an argument from either position or keyword arguments."""
+    if len(args) > pos:
+        return args[pos]
+    if name in kwargs:
+        return kwargs[name]
+    return None


### PR DESCRIPTION
## Description
This PR addresses the problem that logging is inconsistent between the http server and grpc server. When users make /completions/chat calls, they don't get any of the formatted log messages that we've wrapped the grpc invocations with.
Additionally, our existing logs for the grpc server include parts of the request and response, which is often inappropriate for logging in production settings governed by privacy laws and organization policy. This PR also strips that data out of the logging.

To do this, the `EngineClient` that is created at startup has its `generate` method wrapped via `functools.wrap`, and the wrapper logs both request and response information. This ensures that the http and grpc servers log everything the same way, and that we get both request and response logging where we only had response logging before. 

A small challenge here is that we support adding a "correlation id" to logs that should be populated from the `x-correlation-id` header, and at the engine level we have no context about either the http or grpc request to retrieve the header. To get around this, we add a little blackboard cache where we can map request ids to correlation ids. Then in the grpc handlers and in an http middleware method, we fetch the `x-correlation-id` header and cache it with the request id.

An example of the old logging:
```
NFO 12-02 05:36:30 logs.py:155] generate{input=[b'what is the distance between par...'] prefix_id= correlation_id=text-infernece-test-call-31307 adapter_id= input_chars=[53] params=stopping { max_new_tokens: 20 min_new_tokens: 20 } decoding { repetition_penalty: 2.0 } tokenization_time=1.12ms queue_time=0.41ms inference_time=381.83ms time_per_token=19.09ms total_time=383.36ms input_toks=11}: Request generated 20 tokens before MAX_TOKENS, output 101 chars: b' The average flight time from Pa...'
```

And an example of the new logging:
```
INFO 12-06 21:53:18 logs.py:135] Processing request: {request_id=cmpl-foo-0, correlation_id=foo, adapter_id=None,  input_tokens=2,params=SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=1.0, top_p=1.0, top_k=-1, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=16, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None)}
INFO 12-06 21:53:18 logs.py:182] Finished processing request: {request_id=cmpl-foo-0, correlation_id=foo}. Timing info: {queue_time=0.65ms, inference_time=23.25ms, time_per_token=2.33ms, total_time=24.51ms}. Generated 10 tokens before finish reason: stop, output 28 chars
```

A drawback is that this changes the format of the logs from the old TGIS format, but... 🤷 

Will require https://github.com/vllm-project/vllm/pull/10968 for the correlation id to be propagated from the http server

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Just installing the changes and running a server, and sending both grpc and http requests and looking at the logs.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
