### PR TITLE
Fix for python version 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "accelerate==0.34.2",
   "hf-transfer==0.1.8",
   "cachetools~=5.5",
+  "strenum==0.4.15; python_version<'3.11'",
   # additional dependencies for OpenTelemetry tracing
   "opentelemetry-sdk>=1.26.0,<1.28.0",
   "opentelemetry-api>=1.26.0,<1.28.0",

--- a/src/vllm_tgis_adapter/grpc/adapters.py
+++ b/src/vllm_tgis_adapter/grpc/adapters.py
@@ -148,12 +148,10 @@ def _load_adapter_metadata(adapter_id: str, adapter_path: str, unique_id: int) -
     if (Path(adapter_path) / "decoder.pt").exists():
         # Create new temporary directory and convert to peft format there
         # NB: This requires write access to /tmp
-        # Intentionally setting delete=False, we need the new adapter
-        # files to exist for the life of the process
         logger.info("Converting caikit-style adapter %s to peft format", adapter_id)
-        temp_dir = tempfile.TemporaryDirectory(delete=False)
-        convert_pt_to_peft(adapter_path, temp_dir.name)
-        adapter_path = temp_dir.name
+        temp_dir = tempfile.mkdtemp()
+        convert_pt_to_peft(adapter_path, temp_dir)
+        adapter_path = temp_dir
 
     adapter_config_path = Path(adapter_path) / "adapter_config.json"
     if not Path(adapter_config_path).exists():

--- a/src/vllm_tgis_adapter/tgis_utils/metrics.py
+++ b/src/vllm_tgis_adapter/tgis_utils/metrics.py
@@ -1,7 +1,13 @@
 """Implements the logging for all tgi_* metrics for compatibility with TGIS opsviz."""
 
 import time
-from enum import StrEnum, auto
+try:
+    # StrEnum is available in the standard library `enum` from Python 3.11 onwards
+    from enum import StrEnum, auto
+except:
+    # For Python versions < 3.11, StrEnum is not available in the standard library `enum`
+    from enum import auto
+    from strenum import StrEnum
 
 from prometheus_client import Counter, Gauge, Histogram
 from vllm import RequestOutput


### PR DESCRIPTION
This PR includes fixes to run the `vllm-tgis-adapter` using python 3.10

## Description
For Python versions earlier than 3.11, `StrEnum` is not included in the standard library `enum`. Therefore, it is downloaded and imported separately.
The `delete=False` parameter in `tempfile.TemporaryDirectory()` is supported only from Python 3.12 onwards. As a workaround, mkdtemp() is used instead.

## How Has This Been Tested?
Env:
```
Python: 3.10
vLLM: v0.6.4.post2
```
Running tests:
```
pytest --disable-pytest-warnings tests/ | tee output.txt
============================= test session starts ==============================
platform linux -- Python 3.10.13, pytest-8.3.4, pluggy-1.5.0
rootdir: /workspace/vllm-tgis-adapter
configfile: pyproject.toml
plugins: twisted-1.14.3, mock-3.14.0, asyncio-0.25.0, anyio-4.6.2.post1
asyncio: mode=strict, asyncio_default_fixture_loop_scope=None
collected 71 items / 6 deselected / 65 selected

tests/test_adapters.py ......                                            [  9%]
tests/test_grpc_server.py ....s..                                        [ 20%]
tests/test_http_server.py ...                                            [ 24%]
tests/test_init.py .                                                     [ 26%]
tests/test_peft_converter.py .                                           [ 27%]
tests/test_termination_log.py ...                                        [ 32%]
tests/test_tgis_utils.py ............................................    [100%]

=========================== short test summary info ============================
SKIPPED [1] tests/test_grpc_server.py:64: Lora is not available with this configuration
===== 64 passed, 1 skipped, 6 deselected, 19 warnings in 173.80s (0:02:53) =====
```

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
