### PR TITLE
Bump vllm to 0.6.6.post1

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,7 +32,7 @@ jobs:
         pyv: ["3.12"]
         vllm_version:
           # - "" # skip the pypi version as it will not work on CPU
-          - "git+https://github.com/vllm-project/vllm@v0.6.4"
+          - "git+https://github.com/vllm-project/vllm@v0.6.6.post1"
           - "git+https://github.com/vllm-project/vllm@main"
           - "git+https://github.com/opendatahub-io/vllm@main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 requires-python = ">=3.9"
 dynamic = ["version"]
 dependencies = [
-  "vllm>=0.6.4",
+  "vllm>=0.6.6.post1",
   "prometheus_client==0.21.0",
   "grpcio==1.67.0",
   "grpcio-health-checking==1.62.2",

--- a/src/vllm_tgis_adapter/grpc/grpc_server.py
+++ b/src/vllm_tgis_adapter/grpc/grpc_server.py
@@ -62,12 +62,7 @@ if TYPE_CHECKING:
     from grpc.aio import ServicerContext
     from vllm import CompletionOutput, RequestOutput
     from vllm.config import ModelConfig
-
-    try:
-        from vllm.engine.protocol import EngineClient
-    except ImportError:
-        # fallback for versions <=v0.6.1.post2
-        from vllm.engine.protocol import AsyncEngineClient as EngineClient
+    from vllm.engine.protocol import EngineClient
     from vllm.lora.request import LoRARequest
     from vllm.sequence import Logprob
     from vllm.transformers_utils.tokenizer import AnyTokenizer


### PR DESCRIPTION
[vLLM v0.6.5 has been released](https://github.com/vllm-project/vllm/releases/tag/v0.6.5). This PR updates the adapter to ensure compatibility with the latest release.

**TODO:** Additional testing is needed to verify if further updates are necessary.