### PR TITLE
:bug: fixup request cancellation for v0.6.5

### DIFF
--- a/src/vllm_tgis_adapter/grpc/grpc_server.py
+++ b/src/vllm_tgis_adapter/grpc/grpc_server.py
@@ -23,7 +23,6 @@ from vllm.tracing import (
     extract_trace_headers,
     log_tracing_disabled_warning,
 )
-from vllm.utils import iterate_with_cancellation
 
 from vllm_tgis_adapter.logging import init_logger
 from vllm_tgis_adapter.tgis_utils import logs
@@ -262,11 +261,8 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
                 ),
             )
 
-        async def is_cancelled() -> bool:
-            return context.cancelled()
-
         result_generator: AsyncIterator[tuple[int, RequestOutput]] = (
-            merge_async_iterators(*generators, is_cancelled=is_cancelled)
+            merge_async_iterators(*generators)
         )
 
         resp_options = request.params.response
@@ -356,11 +352,6 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
             **adapter_kwargs,
             **kwargs,
         )
-
-        async def is_cancelled() -> bool:
-            return context.cancelled()
-
-        result_generator = iterate_with_cancellation(result_generator, is_cancelled)
 
         resp_options = request.params.response
 


### PR DESCRIPTION
Compatibility fix for vllm v0.6.5

## Description

vLLM has removed the cancellation polling in iterate_with_cancellation and merge_async_iterators, moving it up to the http request handler. This PR removes those integrations, and adds logging integration when requests are cancelled.

It turns out the async grpc server implementation will cancel the task running the handler when the context cancels, so there is no need to poll or implement our own cancellation handling anyway. The LLM engine implementations in vLLM already also catch `asyncio.CancelledError` and abort the work in the engine for us.

TL;DR: We didn't need this anyway

## How Has This Been Tested?
Manual verification of logs and that work is removed from the engine's queues

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
