### PR TITLE
:bug: fixup correlation-id log for grpc calls

### DIFF
--- a/src/vllm_tgis_adapter/tgis_utils/logs.py
+++ b/src/vllm_tgis_adapter/tgis_utils/logs.py
@@ -29,8 +29,9 @@ logger = init_logger(__name__)
 _REQUEST_ID_TO_CORRELATION_ID = cachetools.TTLCache(maxsize=2048, ttl=600)
 
 
-def set_correlation_id(request_id: str, correlation_id: str) -> None:
-    _REQUEST_ID_TO_CORRELATION_ID[request_id] = correlation_id
+def set_correlation_id(request_id: str, correlation_id: str | None) -> None:
+    if correlation_id is not None:
+        _REQUEST_ID_TO_CORRELATION_ID[request_id] = correlation_id
 
 
 def get_correlation_id(request_id: str) -> str | None:


### PR DESCRIPTION
This fixes a goof I made with the `x-correlation-id` grpc metadata header.
I added a unit test this time so I don't break it again 😉 