### PR TITLE
:bug: await init_app_state

### DIFF
--- a/src/vllm_tgis_adapter/http.py
+++ b/src/vllm_tgis_adapter/http.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from typing import TYPE_CHECKING, Callable
 
 from vllm.entrypoints.launcher import serve_http
@@ -46,7 +47,9 @@ async def run_http_server(
         return await call_next(request)
 
     model_config = await engine.get_model_config()
-    init_app_state(engine, model_config, app.state, args)
+    maybe_coroutine = init_app_state(engine, model_config, app.state, args)
+    if inspect.isawaitable(maybe_coroutine):
+        await maybe_coroutine
 
     serve_kwargs = {
         "host": args.host,


### PR DESCRIPTION
## Description
I broke this recently by making a change to vllm's init that will ensure the engine loads all provided lora modules at startup. This broke `init_app_state` because it needed to be async to wait on the engine.

This backwards-compatible change will check if `init_app_state` needs to be awaited, and awaits it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
