### PR TITLE
deps: relax vllm to >= 0.6.4.post1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 requires-python = ">=3.9"
 dynamic = ["version"]
 dependencies = [
-  "vllm>=0.6.6.post1",
+  "vllm>=0.6.4.post2",
   "prometheus_client==0.21.0",
   "grpcio==1.67.0",
   "grpcio-health-checking==1.62.2",


### PR DESCRIPTION
[vllm-gaudi](https://github.com/opendatahub-io/vllm-gaudi/tree/v1.19.0) is currently using v0.6.4.post2, this will make the adapter compatible 


https://issues.redhat.com/browse/RHOAIENG-18052