### PR TITLE
fix: package level logger name 

### DIFF
--- a/src/vllm_tgis_adapter/__main__.py
+++ b/src/vllm_tgis_adapter/__main__.py
@@ -19,14 +19,14 @@ from vllm_tgis_adapter.tgis_utils.logs import add_logging_wrappers
 
 from .grpc import run_grpc_server
 from .http import run_http_server
-from .logging import init_logger
+from .logging import DEFAULT_LOGGER_NAME, init_logger
 from .tgis_utils.args import EnvVarArgumentParser, add_tgis_args, postprocess_tgis_args
 from .utils import check_for_failed_tasks, write_termination_log
 
 if TYPE_CHECKING:
     import argparse
 
-logger = init_logger("vllm-tgis-adapter")
+logger = init_logger(DEFAULT_LOGGER_NAME)
 
 
 async def start_servers(args: argparse.Namespace) -> None:

--- a/src/vllm_tgis_adapter/logging.py
+++ b/src/vllm_tgis_adapter/logging.py
@@ -5,16 +5,18 @@ from vllm.logger import (
     init_logger,  # noqa: F401
 )
 
+DEFAULT_LOGGER_NAME = __name__.split(".")[0]
+
 config = {**DEFAULT_LOGGING_CONFIG}
 
-config["formatters"]["vllm_tgis_adapter"] = DEFAULT_LOGGING_CONFIG["formatters"]["vllm"]
+config["formatters"][DEFAULT_LOGGER_NAME] = DEFAULT_LOGGING_CONFIG["formatters"]["vllm"]
 
 handler_config = DEFAULT_LOGGING_CONFIG["handlers"]["vllm"]
-handler_config["formatter"] = "vllm_tgis_adapter"
-config["handlers"]["vllm_tgis_adapter"] = handler_config
+handler_config["formatter"] = DEFAULT_LOGGER_NAME
+config["handlers"][DEFAULT_LOGGER_NAME] = handler_config
 
 logger_config = DEFAULT_LOGGING_CONFIG["loggers"]["vllm"]
-logger_config["handlers"] = ["vllm_tgis_adapter"]
-config["loggers"]["vllm_tgis_adapter"] = logger_config
+logger_config["handlers"] = [DEFAULT_LOGGER_NAME]
+config["loggers"][DEFAULT_LOGGER_NAME] = logger_config
 
 logging.config.dictConfig(config)

--- a/src/vllm_tgis_adapter/utils.py
+++ b/src/vllm_tgis_adapter/utils.py
@@ -26,9 +26,9 @@ def write_termination_log(msg: str, file: str = "/dev/termination-log") -> None:
         # Ignore any errors writing to the termination logfile.
         # Users can fall back to the stdout logs, and we don't want to pollute
         # those with an error here.
-        from .logging import init_logger
+        from .logging import DEFAULT_LOGGER_NAME, init_logger
 
-        logger = init_logger("vllm-tgis-adapter")
+        logger = init_logger(DEFAULT_LOGGER_NAME)
         logger.exception("Unable to write termination logs to %s", file)
 
 


### PR DESCRIPTION
## Description

Before this change, the logging configuration was set for the name `"vllm_tgis_adapter"`, but the loggers used `"vllm-tgis-adapter"`. Logging calls in `__main__` would therefore not be printed.

## How Has This Been Tested?
Launching the server should now result in logs like these showing all of the server's arguments:
```
INFO 02-12 21:20:32 __main__.py:108] vLLM version 0.7.1
INFO 02-12 21:20:32 __main__.py:109] args: Namespace(host=None, port=8000, uvicorn_log_level='info', allow_credentials=False, allowed_origins=['*'], allowed_methods=['*'], allowed_headers=['*'], api_key=None, lora_modules=None, ..., speculator_max_batch_size=None, enable_vllm_log_requests=False, disable_prompt_logprobs=False)
```


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
