### PR TITLE
Pass param for pre-created socket to uvicorn

### DIFF
--- a/src/vllm_tgis_adapter/http.py
+++ b/src/vllm_tgis_adapter/http.py
@@ -63,7 +63,7 @@ async def run_http_server(
     }
     serve_kwargs.update(uvicorn_kwargs)
 
-    shutdown_coro = await serve_http(app, **serve_kwargs)
+    shutdown_coro = await serve_http(app, sock=None, **serve_kwargs)
 
     # launcher.serve_http returns a shutdown coroutine to await
     # (The double await is intentional)

--- a/src/vllm_tgis_adapter/http.py
+++ b/src/vllm_tgis_adapter/http.py
@@ -63,7 +63,12 @@ async def run_http_server(
     }
     serve_kwargs.update(uvicorn_kwargs)
 
-    shutdown_coro = await serve_http(app, sock=None, **serve_kwargs)
+    from vllm.version import __version_tuple__ as vllm_version_tuple
+    ...
+    if vllm_version_tuple >= (0, 7, 3):
+        serve_kargs['sock'] = None
+        
+    shutdown_coro = await serve_http(app, **serve_kwargs)
 
     # launcher.serve_http returns a shutdown coroutine to await
     # (The double await is intentional)


### PR DESCRIPTION
During the integration tests, the built image triggered the error below:
```
[rank0]:[W215 15:13:14.568778632 ProcessGroupNCCL.cpp:1496] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
Traceback (most recent call last):
  File "/opt/vllm/lib64/python3.12/site-packages/vllm_tgis_adapter/http.py", line 66, in run_http_server
    shutdown_coro = await serve_http(app, **serve_kwargs)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: serve_http() missing 1 required positional argument: 'sock'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/opt/vllm/lib64/python3.12/site-packages/vllm_tgis_adapter/__main__.py", line 114, in <module>
    run_and_catch_termination_cause(loop, task)
  File "/opt/vllm/lib64/python3.12/site-packages/vllm_tgis_adapter/__main__.py", line 90, in run_and_catch_termination_cause
    loop.run_until_complete(task)
  File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
  File "/opt/vllm/lib64/python3.12/site-packages/vllm_tgis_adapter/__main__.py", line 80, in start_servers
    raise RuntimeError(f"Failed task={name} ({coro_name})") from exception
RuntimeError: Failed task=http_server (run_http_server)
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
E0000 00:00:1739632399.252718       1 init.cc:232] grpc_wait_for_shutdown_with_timeout() timed out.
```

Looking for the function `serve_http()` in `vllm/entrypoints/launcher.py`, I found that a recent modification in PR [#13113](https://github.com/vllm-project/vllm/pull/13113) (post vLLM v0.7.2) added an optional parameter `sock` to allow uvicorn to use a pre-created socket.

We actually use the `serve_http()` function in `/src/vllm_tgis_adapter/http.py`. Because of this, I added a parameter `sock=None` to maintain the same function signature we used before. I'm not sure if we need to use a pre-created socket for multi-GPU support or for something else.