### PR TITLE
Add VLLM_LOG_FILTER_PATTERNS arg

### DIFF
--- a/src/vllm_tgis_adapter/tgis_utils/args.py
+++ b/src/vllm_tgis_adapter/tgis_utils/args.py
@@ -160,7 +160,9 @@ def add_tgis_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         "--disable-prompt-logprobs", type=_bool_from_string, default=False
     )
     parser.add_argument(
-        "--vllm-log-filter-patterns", type=str, default='["GuidedDecodingParams([^)]*)"]'
+        "--vllm-log-filter-patterns",
+        type=str,
+        default='["GuidedDecodingParams([^)]*)"]',
     )
 
     # TODO check/add other args here

--- a/src/vllm_tgis_adapter/tgis_utils/args.py
+++ b/src/vllm_tgis_adapter/tgis_utils/args.py
@@ -159,6 +159,9 @@ def add_tgis_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     parser.add_argument(
         "--disable-prompt-logprobs", type=_bool_from_string, default=False
     )
+    parser.add_argument(
+        "--vllm-log-filter-patterns", type=str, default='["GuidedDecodingParams([^)]*)"]'
+    )
 
     # TODO check/add other args here
 


### PR DESCRIPTION
Setting a default `VLLM_LOG_FILTER_PATTERNS` env var to redact guided decoding params  