### PR TITLE
gha: use inline annotations for ruff linting errors

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -80,6 +80,8 @@ jobs:
 
       - name: Lint code and check dependencies
         run: nox --envdir ~/.nox --reuse-venv=yes -v -s lint-${{ matrix.pyv }}
+        env:
+          RUFF_OUTPUT_FORMAT: github
 
       - name: Cache ccache cache directory
         id: cache-ccache


### PR DESCRIPTION
Makes it easier to read ruff linting errors in CI
