### PR TITLE
redact guided decoding params

### DIFF
--- a/src/vllm_tgis_adapter/tgis_utils/logs.py
+++ b/src/vllm_tgis_adapter/tgis_utils/logs.py
@@ -134,6 +134,22 @@ def _log_cancellation(request_id: str, correlation_id: str) -> None:
     )
 
 
+def _sanitize_sampling_params(params: SamplingParams) -> str:
+    """Sanitize sampling parameters for logging."""
+    original_params = str(params)
+
+    if params.guided_decoding is not None:
+        # Redact guided decoding params
+        guided_decoding_params = str(params.guided_decoding)
+        sanitized_params = original_params.replace(
+            guided_decoding_params,
+            "(...)",
+        )
+        return sanitized_params
+
+    return original_params
+
+
 def _log_request(
     request_id: str,
     params: SamplingParams,
@@ -145,6 +161,9 @@ def _log_request(
         input_tokens = f" input_tokens={len(prompt['prompt_token_ids'])},"
     else:
         input_tokens = ""
+
+    sanitized_params = _sanitize_sampling_params(params)
+
     logger.info(
         "Processing request: {request_id=%s, correlation_id=%s, adapter_id=%s, "
         "%sparams=%s}",
@@ -152,7 +171,7 @@ def _log_request(
         correlation_id,
         adapter_id,
         input_tokens,
-        params,
+        sanitized_params,
     )
 
 


### PR DESCRIPTION
Santizes sampling parameters of guided decoding params (which can be considered private data) if they exist to avoid logging them.

## Description
Add a `_sanitize_sampling_params` function which replaces the guided_decoding data with `(...)` if it exists, in a way that avoids modifying `SamplingParams`. 

## How Has This Been Tested?
Output:
```
INFO 03-06 17:13:48 [logs.py:165] Processing request: {request_id=cmpl-28a0ef39c68a40b1956e61f272c09169-0, correlation_id=None, adapter_id=None,  input_tokens=41,params=SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.7, top_p=1.0, top_k=-1, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=512, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=(...))}