### PR TITLE
fix after change to MistralTokenizer upstream

### DIFF
--- a/src/vllm_tgis_adapter/grpc/grpc_server.py
+++ b/src/vllm_tgis_adapter/grpc/grpc_server.py
@@ -844,9 +844,7 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
                     raise ValueError(
                         f"{type(tokenizer)} doesn't support the return_offsets option"
                     )
-                token_ids = tokenizer.encode(
-                    prompt=req.text,
-                )
+                token_ids = tokenizer.encode(req.text)
             else:
                 batch_encoding = tokenizer.encode_plus(
                     text=req.text,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

[This change in upstream vLLM for v0.7.3](https://github.com/vllm-project/vllm/pull/12518/files#diff-7b4368a1d7d34fa1071838db6d63fea4911f32e60ac065829979b327ad539649R325) modified the interface to the `MistralTokenizer`'s `encode` function, changing the parameter name from `prompt` to `text`. After that change, the Tokenize endpoint in the adapter broke when using `--tokenizer-mode=mistral`. This PR fixes it in a backwards compatible way by changing to a positional argument.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in a dev environment with a mistral tokenizer, confirming that the tokenize endpiont works with v0.7.3 and v0.7.2 with a basic request:

```
python -m vllm_tgis_adapter --model mistralai/Mistral-7B-Instruct-v0.3 --tokenizer-mode mistral
```

```
  grpcurl -plaintext -proto proto/generation.proto -d \
    '{
      "model_id": "unused",
      "requests": [
        {
          "text": "Hello World"
        }
      ]
    }' \
    localhost:8033 fmaas.GenerationService/Tokenize
 ```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
