### PR TITLE
gha: fix ci caching

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -78,6 +78,13 @@ jobs:
           path: /home/runner/.nox
           key: ${{ runner.os }}-python-${{matrix.pyv}}-${{ hashFiles('noxfile.py') }}-${{matrix.vllm_version}}
 
+      - name: hf hub cache
+        id: hf-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface/hub
+          key: ${{ runner.os }}
+
       - name: Lint code and check dependencies
         run: nox --envdir ~/.nox --reuse-venv=yes -v -s lint-${{ matrix.pyv }}
         env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /home/runner/.nox
-          key: ${{ runner.os }}-python-${{steps.setup-python.outputs.python-version }}-${{ hashFiles('noxfile.py') }}
+          key: ${{ runner.os }}-python-${{matrix.pyv}}-${{ hashFiles('noxfile.py') }}-${{matrix.vllm_version}}
 
       - name: Lint code and check dependencies
         run: nox --envdir ~/.nox --reuse-venv=yes -v -s lint-${{ matrix.pyv }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,6 +18,7 @@ env:
   UV_EXTRA_INDEX_URL: "https://download.pytorch.org/whl/cpu"
   # have uv match pip's behaviour for extra index operations
   UV_INDEX_STRATEGY: "unsafe-best-match"
+  VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
- python version cache key was referring to an old (now unset) variable
- add vllm version as nox envs cache key
- cache huggingface hub directory, this should prevent getting temporary 403 errors from huggingface, which has made CI flakey lately
