### PR TITLE
Compatibility with vLLM v1 engine

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,6 +110,7 @@ def args(  # noqa: PLR0913
             "__main__.py",
             f"--grpc-port={grpc_server_port}",
             f"--port={http_server_port}",
+            "--dtype=float32",
             *extra_args,
         ],
     )


### PR DESCRIPTION
Changes from my testing of the adapter with the V1 engine, backwards compatible

## Description
vLLM >=0.8 now enables the V1 engine by default

## How Has This Been Tested?
Tested manually with a handful of gRPC and HTTP requests with vLLM running with V0 and V1.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
