### PR TITLE
:recycle: Consolidate vllm utils and allow vllm version to be overwritten

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -23,6 +23,11 @@ def tests(session: nox.Session) -> None:
 
     session.install(".[tests]")
 
+    # Re-install without dependencies since `.[tests]` brings in
+    # overrides that may bring the vllm version down
+    if vllm_version := os.getenv("VLLM_VERSION_OVERRIDE"):
+        session.install(vllm_version, "--no-deps")
+
     session.run(
         "pytest",
         "--cov",

--- a/src/vllm_tgis_adapter/http.py
+++ b/src/vllm_tgis_adapter/http.py
@@ -46,8 +46,12 @@ async def build_http_server(
 
         return await call_next(request)
 
-    model_config = await engine.get_model_config()
-    maybe_coroutine = init_app_state(engine, model_config, app.state, args)
+    if hasattr(engine, "get_vllm_config"):
+        vllm_config = await engine.get_vllm_config()
+        maybe_coroutine = init_app_state(engine, vllm_config, app.state, args)
+    else:
+        model_config = await engine.get_model_config()
+        maybe_coroutine = init_app_state(engine, model_config, app.state, args)
     if inspect.isawaitable(maybe_coroutine):
         await maybe_coroutine
 

--- a/src/vllm_tgis_adapter/tgis_utils/args.py
+++ b/src/vllm_tgis_adapter/tgis_utils/args.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import argparse
 import os
 
-from vllm.engine.arg_utils import StoreBoolean
-from vllm.utils import FlexibleArgumentParser
+from vllm.utils import FlexibleArgumentParser, StoreBoolean
 
 from vllm_tgis_adapter.grpc.validation import MAX_TOP_N_TOKENS
 from vllm_tgis_adapter.logging import init_logger

--- a/tests/test_tgis_utils.py
+++ b/tests/test_tgis_utils.py
@@ -1,8 +1,7 @@
 import sys
 
 import pytest
-from vllm.engine.arg_utils import StoreBoolean
-from vllm.utils import FlexibleArgumentParser
+from vllm.utils import FlexibleArgumentParser, StoreBoolean
 
 from vllm_tgis_adapter.tgis_utils.args import (
     EnvVarArgumentParser,


### PR DESCRIPTION
## Description
- PR `https://github.com/vllm-project/vllm/pull/16533` will remove the import of `StoreBoolean` through `vllm.engine.arg_utils`, but since this is done by an import from `vllm.utils` anyway, the import can be directly used
- It appeared the wrong vllm versions were being "tested" during the tests - this has been updated
- PR `https://github.com/vllm-project/vllm/pull/16572` will change the inputs to `init_app_state` from `model_config` to `vllm_config`


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Mainly discovered through another adapter and tested with previous versions of vllm (0.8.1-0.8.2, discovered the problem with latest main)

For the vllm version addition (see #248) : 
Other dependencies in `.[tests]` appear to be changing the vllm version itself from the initial override - a suspected example is something like `https://github.com/vllm-project/vllm/pull/15224` where the opentelemetry dependencies are pinned lower than what this adapter currently allows.

However, swapping the `.[tests]` and vllm version dependencies entirely also led to unexpected behavior such as overriding protobuf versions, leading to more issues. The compromise then appeared to be re-installing the expected vllm version itself without dependencies

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
