### PR TITLE
:recycle::bug: Allow vllm version to be overwritten

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -18,10 +18,12 @@ versions = [
 
 @nox.session(python=versions)
 def tests(session: nox.Session) -> None:
-    session.install(".[tests]")
-
     if vllm_version := os.getenv("VLLM_VERSION_OVERRIDE"):
         session.install(vllm_version)
+
+    session.install(".[tests]")
+    if vllm_version := os.getenv("VLLM_VERSION_OVERRIDE"):
+        session.install(vllm_version, "--no-deps")
 
     session.run(
         "pytest",


### PR DESCRIPTION
## Description
Was noticing in https://github.com/opendatahub-io/vllm-tgis-adapter/actions/runs/14478194054/job/40896465872?pr=247 that the vllm version did not appear to be the one on main as expected

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
