### PR TITLE
:fire: remove version pins for opentelemetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,12 +33,7 @@ dependencies = [
   "grpcio-reflection==1.70.0",
   "accelerate==1.6.0",
   "hf-transfer==0.1.9",
-  "cachetools~=5.5",
-  # additional dependencies for OpenTelemetry tracing
-  "opentelemetry-sdk>=1.30.0",
-  "opentelemetry-api>=1.30.0",
-  "opentelemetry-exporter-otlp>=1.28.0",
-  "opentelemetry-semantic-conventions-ai>=0.4.1"
+  "cachetools~=5.5"
 ]
 
 [project.urls]


### PR DESCRIPTION
## Description
The adapter itself does not depend on the `opentelemetry-*` packages, it uses vllm utility functions and vllm itself defines the dependency on opentelemetry. The dependency on opentelemetry here was initially added in https://github.com/opendatahub-io/vllm-tgis-adapter/pull/20, because at the time `opentelemetry` was not listed in vllm's requirements: https://github.com/vllm-project/vllm/blob/v0.5.4/requirements-common.txt

This was later updated in https://github.com/opendatahub-io/vllm-tgis-adapter/pull/106, to update the dependency range here to match what vllm expected to be installed, to avoid conflicts.

However, vLLM has since corrected its requirements to specify opentelemetry, with a version range pinned: https://github.com/vllm-project/vllm/blob/main/requirements/common.txt#L46-L49. This now does conflict with the pin here, which causes installs to fail to resolve to recent vllm versions.

We should be good to follow the standard dependency management scheme here of not specifying transitive dependencies, so this PR removes the declaration of `opentelemetry-*` packages as dependencies.

This doesn't totally fix the version resolution problem though, since the versions of `opentelemetry` specified by vllm conflict with the `grpcio` packages required here by the adapter 😞 

## How Has This Been Tested?

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
