### PR TITLE
main entrypoint: set env vars like vllm does

### DIFF
--- a/src/vllm_tgis_adapter/__main__.py
+++ b/src/vllm_tgis_adapter/__main__.py
@@ -106,6 +106,9 @@ def run_and_catch_termination_cause(
 
 
 if __name__ == "__main__":
+    from vllm.entrypoints.utils import cli_env_setup
+
+    cli_env_setup()
     parser = FlexibleArgumentParser("vLLM TGIS GRPC + OpenAI REST api server")
     # convert to our custom env var arg parser
     parser = EnvVarArgumentParser(parser=make_arg_parser(parser))


### PR DESCRIPTION

`cli_env_setup` is responsible for setting `VLLM_WORKER_MULTIPROC_METHOD='spawn'` if the user hasn't overridden it through environment variables.

See https://github.com/vllm-project/vllm/blob/v0.10.0/vllm/entrypoints/utils.py#L151


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved environment setup during application startup for smoother initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->