### PR TITLE
unpin vllm for rocm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 requires-python = ">=3.9"
 dynamic = ["version"]
 dependencies = [
-  "vllm>=0.10.0",
+  "vllm",
   "prometheus_client==0.21.1",
   "grpcio==1.70.0",
   "grpcio-health-checking==1.70.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
ROCM Build fails with
```
[8/8] STEP 4/8: RUN --mount=type=cache,target=/root/.cache/pip     --mount=type=cache,target=/root/.cache/uv     --mount=type=bind,from=build_vllm,src=/workspace/dist,target=/install/vllm/     HOME=/root uv pip install         "$(echo /install/vllm/*.whl)[audio,video,tensorizer]"         vllm-tgis-adapter==${VLLM_TGIS_ADAPTER_VERSION}
Using Python 3.12.9 environment at: /opt/vllm
  × No solution found when resolving dependencies:
  ╰─▶ Because only vllm[audio]==0.1.dev8486+ga2a0e2a.rocm634 is available
      and vllm-tgis-adapter==0.8.0 depends on vllm>=0.10.0, we can conclude
      that vllm-tgis-adapter==0.8.0 and all versions of vllm[audio] are
      incompatible.
      And because you require vllm-tgis-adapter==0.8.0 and vllm[audio], we can
      conclude that your requirements are unsatisfiable.
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the "vllm" dependency to remove the minimum version requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->