### PR TITLE
fix vllm build

### DIFF
--- a/.github/scripts/install_vllm_build_deps.py
+++ b/.github/scripts/install_vllm_build_deps.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env -S uv run --active --script
+# /// script
+# dependencies = [
+#   "tomli",
+# ]
+# ///
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from subprocess import run
+
+import tomli
+
+
+def _get_build_dependencies_from_file(pyproject: Path) -> list[str]:
+    if not pyproject.exists():
+        raise FileNotFoundError(f"{pyproject} does not exist.")
+
+    with pyproject.open("rb") as fh:
+        pyproject_data = tomli.load(fh)
+
+    build_system = pyproject_data.get("build-system", {})
+    requires = build_system.get("requires", [])
+
+    if not requires:
+        raise ValueError("[build-system.requires] is empty")
+
+    return requires
+
+
+def install_vllm_build_deps(
+    pyproject_file: str | None = None,
+    constraints: str | Path | None = None,
+) -> None:
+    """Installs vllm build deps parsing them from the given vllm repo path/url.
+
+    This is required because the vllm CPU build for PEP517/PEP518 style build is broken
+    and we have to manually install build dependencies and use --no-build-isolation.
+    """
+    pyproject = Path(pyproject_file or "pyproject.toml")
+    if not constraints:
+        constraints = pyproject.parent / "requirements" / "cpu.txt"
+    build_deps = _get_build_dependencies_from_file(pyproject)
+
+    run(  # noqa: S603
+        (
+            "uv",
+            "pip",
+            "install",
+            f"--overrides={constraints.resolve()}",
+            *build_deps,
+        ),
+        check=True,
+    )
+
+
+if __name__ == "__main__":
+    install_vllm_build_deps(
+        sys.argv[1] if sys.argv[1:] else None,  # pyproject path
+        sys.argv[2] if sys.argv[2:] else None,  # constraint file (default=cpu)
+    )

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,10 +21,13 @@ env:
   # have uv match pip's behaviour for extra index operations
   UV_INDEX_STRATEGY: "unsafe-best-match"
   VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+  VLLM_REPO: "vllm-project/vllm"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
+
+
 
 jobs:
   tests:
@@ -35,10 +38,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         pyv: ["3.12"]
-        vllm_version:
-          # - "" # skip the pypi version as it will not work on CPU
-          - "git+https://github.com/vllm-project/vllm@v0.10.0"
-          - "git+https://github.com/vllm-project/vllm@main"
+        vllm_ref:
+          - "v0.10.0"
+          - "main"
 
     steps:
       - name: Check out the repository
@@ -61,7 +63,7 @@ jobs:
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml
-          cache-suffix: ${{matrix.vllm_version}}
+          cache-suffix: ${{matrix.vllm_ref}}
 
       - name: Install nox
         run: |
@@ -72,7 +74,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /home/runner/.nox
-          key: ${{ runner.os }}-python-${{matrix.pyv}}-${{ hashFiles('noxfile.py') }}-${{matrix.vllm_version}}
+          key: ${{ runner.os }}-python-${{matrix.pyv}}-${{ hashFiles('noxfile.py') }}-${{matrix.vllm_ref}}
 
       - name: hf hub cache
         id: hf-cache
@@ -93,15 +95,33 @@ jobs:
           path: /home/runner/.cache/ccache
           key: ${{ runner.os }}
 
-      - name: build vllm
-        run: nox --envdir ~/.nox --reuse-venv=yes -v -s build_vllm-${{ matrix.pyv }}
-        env:
-          VLLM_VERSION_OVERRIDE: ${{ matrix.vllm_version }}
+      - name: Check out the vllm repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          repository: ${{ env.VLLM_REPO }}
+          ref: ${{ matrix.vllm_ref }}
+          path: vllm
+
+      - name: Build vllm
+        run: |
+          cd vllm
+
+          uv venv .venv
+          source .venv/bin/activate
+
+          uv pip install --overrides requirements/cpu.txt --requirements requirements/build.txt
+
+          python -m setup.py bdist_wheel
+
+      - name: Set vllm version override env var
+        run: |
+          vllm_wheel="$(find vllm/dist -name '*.whl' -exec realpath {} \;)"
+
+          echo "VLLM_VERSION_OVERRIDE=$vllm_wheel" | tee -a "$GITHUB_ENV"
 
       - name: Run tests
         run: nox --envdir ~/.nox --reuse-venv=yes -v -s tests-${{ matrix.pyv }} -- --cov-report=xml
-        env:
-          VLLM_VERSION_OVERRIDE: ${{ matrix.vllm_version }}
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v5

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,13 +46,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          tool-cache: false
-          large-packages: false
-          docker-images: false
-
       - name: Install vLLM build deps
         run: |
           sudo apt update

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,6 +17,7 @@ env:
   UV_EXTRA_INDEX_URL: "https://download.pytorch.org/whl/cpu"
   # have uv match pip's behaviour for extra index operations
   UV_INDEX_STRATEGY: "unsafe-best-match"
+  VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
   VLLM_REPO: "vllm-project/vllm"
   # vllm configuration
   VLLM_USE_V1: 1 # starting from v0.10.0, V1 must be enabled on CPU

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,10 +12,7 @@ on:
 env:
   FORCE_COLOR: "1"
   # facilitate testing by building vLLM for CPU when needed
-  VLLM_CPU_DISABLE_AVX512: "true"
   VLLM_TARGET_DEVICE: "cpu"
-  VLLM_CPU_ONLY: "1"
-  CMAKE_ARGS: "-DVLLM_CPU_ONLY=ON"
   # prefer index for torch cpu version
   UV_EXTRA_INDEX_URL: "https://download.pytorch.org/whl/cpu"
   # have uv match pip's behaviour for extra index operations

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,8 +24,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-
-
 jobs:
   tests:
     timeout-minutes: 30
@@ -107,9 +105,9 @@ jobs:
           uv venv .venv
           source .venv/bin/activate
 
-          uv pip install --overrides requirements/cpu.txt --requirements requirements/build.txt
+          $GITHUB_WORKSPACE/.github/scripts/install_vllm_build_deps.py
 
-          python -m setup.py bdist_wheel
+          python setup.py bdist_wheel
 
       - name: Set vllm version override env var
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,6 @@ env:
   UV_EXTRA_INDEX_URL: "https://download.pytorch.org/whl/cpu"
   # have uv match pip's behaviour for extra index operations
   UV_INDEX_STRATEGY: "unsafe-best-match"
-  VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
   VLLM_REPO: "vllm-project/vllm"
 
 concurrency:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,6 +18,8 @@ env:
   # have uv match pip's behaviour for extra index operations
   UV_INDEX_STRATEGY: "unsafe-best-match"
   VLLM_REPO: "vllm-project/vllm"
+  # vllm configuration
+  VLLM_USE_V1: 1 # starting from v0.10.0, V1 must be enabled on CPU
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/README.md
+++ b/README.md
@@ -86,11 +86,22 @@ The standard vllm built requires an Nvidia GPU. When this is not available, it i
 
 ```bash
 
-env \
-    VLLM_CPU_DISABLE_AVX512=true VLLM_TARGET_DEVICE=cpu \
-    UV_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu \
+git clone https://github.com/vllm-project/vllm
+cd vllm
+
+uv venv
+source .venv/bin/activate
+
+export UV_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu \
     UV_INDEX_STRATEGY=unsafe-best-match\
-    uv pip install git+https://github.com/vllm-project/vllm
+
+.github/scripts/install_vllm_build_deps.py pyproject.toml
+
+env \
+    VLLM_TARGET_DEVICE=cpu \
+    python setup.py bdist_wheel
+export VLLM_VERSION_OVERRIDE=$PWD/dist/*whl
+# the nox session can now be run with the custom built vllm cpu version
 ```
 
 making it possible to run the tests on most hardware. Please note that the `uv` extra index url is required in order to install the torch CPU version.

--- a/noxfile.py
+++ b/noxfile.py
@@ -80,7 +80,7 @@ def install_vllm_build_deps(session: nox.Session, vllm_version: str) -> None:
         pyproject = Path(vllm_version) / "pyproject.toml"
         build_deps = _get_build_dependencies_from_file(pyproject)
     elif vllm_version.startswith("git+https://github.com/"):
-        url = vllm_version.lstrip("git+")
+        url = vllm_version.lstrip("git+").rstrip(".git")
         if "@" in vllm_version:
             url, ref = url.split("@")
         else:

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,15 @@
+import importlib
 import os
+import urllib.request
+from functools import lru_cache
 from pathlib import Path
 
 import nox
+
+try:
+    import tomllib
+except ImportError:
+    import tomli  # nox installs toml for python<3.11
 
 nox.options.reuse_existing_virtualenvs = True
 nox.options.sessions = "lint", "tests"
@@ -16,23 +24,105 @@ versions = [
 ]
 
 
+@lru_cache
+def _get_build_dependencies_from_file(pyproject: Path) -> list[str]:
+    if not pyproject.exists():
+        raise FileNotFoundError(f"{pyproject} does not exist.")
+
+    with pyproject.open("rb") as fh:
+        lib = tomllib if importlib.util.find_spec("tomllib") else tomli
+        pyproject_data = lib.load(fh)
+
+    build_system = pyproject_data.get("build-system", {})
+    requires = build_system.get("requires", [])
+
+    if not requires:
+        raise ValueError("[build-system.requires] is empty")
+
+    return requires
+
+
+@lru_cache
+def _get_build_dependencies_from_repo(repo_url: str, ref: str) -> list[str]:
+    """Retrieve build dependencies from pyproject.toml for the given github repo/ref."""
+    assert repo_url.startswith("https://github.com/"), (
+        "this can only work with github urls"
+    )
+
+    raw_url = (
+        repo_url.replace("github.com", "raw.githubusercontent.com")
+        + f"/{ref}/pyproject.toml"
+    )
+
+    response = urllib.request.urlopen(raw_url)  # noqa: S310
+    data = response.read()
+
+    lib = tomllib if importlib.util.find_spec("tomllib") else tomli
+    pyproject_data = lib.loads(data.decode())
+
+    build_system = pyproject_data.get("build-system", {})
+    requires = build_system.get("requires", [])
+
+    if not requires:
+        raise ValueError("[build-system.requires] is empty")
+
+    return requires
+
+
+def install_vllm_build_deps(session: nox.Session, vllm_version: str) -> None:
+    """Installs vllm build deps parsing them from the given vllm repo path/url.
+
+    This is required because the vllm CPU build for PEP517/PEP518 style build is broken
+    and we have to manually install build dependencies and use --no-build-isolation.
+    """
+    maybe_repo_path = Path(vllm_version)
+    if maybe_repo_path.exists() and (maybe_repo_path / "pyproject.toml").exists():
+        pyproject = Path(vllm_version) / "pyproject.toml"
+        build_deps = _get_build_dependencies_from_file(pyproject)
+    elif vllm_version.startswith("git+https://github.com/"):
+        url = vllm_version.lstrip("git+")
+        if "@" in vllm_version:
+            url, ref = url.split("@")
+        else:
+            import warnings
+
+            ref = "main"
+            warnings.warn(f"Ref not specified, assuming to be {ref}", stacklevel=2)
+
+        build_deps = _get_build_dependencies_from_repo(url, ref)
+
+    else:
+        raise NotImplementedError(
+            f"{vllm_version=} does not exist or url scheme is unsupported"
+        )
+
+    if not build_deps:
+        raise ValueError("build deps are empty?")
+
+    session.install(*build_deps)
+
+
+def install_vllm_if_overridden(session: nox.Session) -> None:
+    if vllm_version := os.getenv("VLLM_VERSION_OVERRIDE"):
+        install_vllm_build_deps(session, vllm_version)
+        session.install("--no-build-isolation", vllm_version)
+
+
 @nox.session(python=versions)
 def build_vllm(session: nox.Session) -> None:
-    if vllm_version := os.getenv("VLLM_VERSION_OVERRIDE"):
-        session.install(vllm_version)
+    install_vllm_if_overridden(session)
 
 
 @nox.session(python=versions)
 def tests(session: nox.Session) -> None:
-    if vllm_version := os.getenv("VLLM_VERSION_OVERRIDE"):
-        session.install(vllm_version)
+    install_vllm_if_overridden(session)
 
     session.install(".[tests]")
 
-    # Re-install without dependencies since `.[tests]` brings in
-    # overrides that may bring the vllm version down
-    if vllm_version := os.getenv("VLLM_VERSION_OVERRIDE"):
-        session.install(vllm_version, "--no-deps")
+    # Re-install vllm since `.[tests]` brings in
+    # overrides that may bring the vllm version down.
+    # Should be a no-op most of the time.
+    install_vllm_if_overridden(session)
 
     session.run(
         "pytest",

--- a/noxfile.py
+++ b/noxfile.py
@@ -37,6 +37,7 @@ def tests(session: nox.Session) -> None:
         "--cov",
         "--cov-config=pyproject.toml",
         "--no-cov-on-fail",
+        "tests",
         *session.posargs,
         env={"COVERAGE_FILE": f".coverage.{session.python}"},
     )

--- a/noxfile.py
+++ b/noxfile.py
@@ -46,7 +46,6 @@ def tests(session: nox.Session) -> None:
 @nox.session(python=versions)
 def lint(session: nox.Session) -> None:
     session.install("pre-commit")
-    session.install("-e", ".[dev]")
 
     if run_mypy := "--mypy" in session.posargs:
         session.posargs.remove("--mypy")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,9 @@ select = ["ALL"]
   "BLE001",
   "PLR0913"
 ]
+".github/scripts/install_vllm_build_deps.py" = [
+  "EXE003"
+]
 
 [tool.ruff.lint.flake8-type-checking]
 strict = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,7 +105,6 @@ def args(  # noqa: PLR0913
             f"--grpc-port={grpc_server_port}",
             f"--port={http_server_port}",
             "--dtype=float32",
-            "--device=cpu",
             *extra_args,
         ],
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,7 @@ def args(  # noqa: PLR0913
             f"--grpc-port={grpc_server_port}",
             f"--port={http_server_port}",
             "--dtype=float32",
+            "--max-model-len=512",
             *extra_args,
         ],
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,7 +89,6 @@ def args(  # noqa: PLR0913
             "__main__.py",
             f"--grpc-port={grpc_server_port}",
             f"--port={http_server_port}",
-            "--dtype=float32",
             "--max-model-len=512",
             *extra_args,
         ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,7 +195,7 @@ def _servers(
     t.start()
 
     try:
-        wait_until(_health_check)
+        wait_until(_health_check, timeout=300, pause=10)
         yield
     finally:
         if task:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 
 @pytest.fixture
 def lora_available() -> bool:
-    # lora does not work on cpu
+    # lora works on CPU since v0.10.0
     return not vllm.platforms.current_platform.is_cpu()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Annotated, TypeVar
 
 import pytest
 import requests
-import vllm
 from vllm.entrypoints.openai.cli_args import make_arg_parser
 from vllm.utils import FlexibleArgumentParser
 
@@ -33,24 +32,12 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture
-def lora_available() -> bool:
-    # lora does not work on cpu
-    return not vllm.platforms.current_platform.is_cpu()
-
-
-@pytest.fixture
 def lora_adapter_name(request: pytest.FixtureRequest) -> str:
-    if not request.getfixturevalue("lora_available"):
-        pytest.skip("Lora is not available with this configuration")
-
     return "lora-test"
 
 
 @pytest.fixture
 def lora_adapter_path(request: pytest.FixtureRequest) -> str:
-    if not request.getfixturevalue("lora_available"):
-        pytest.skip("Lora is not available with this configuration")
-
     from huggingface_hub import snapshot_download
 
     path = snapshot_download(repo_id="yard1/llama-2-7b-sql-lora-test")
@@ -79,7 +66,6 @@ def args(  # noqa: PLR0913
     monkeypatch,
     grpc_server_port: ArgFixture[int],
     http_server_port: ArgFixture[int],
-    lora_available: ArgFixture[bool],
     disable_frontend_multiprocessing,
     server_args: ArgFixture[list[str]],
 ) -> argparse.Namespace:
@@ -88,11 +74,10 @@ def args(  # noqa: PLR0913
 
     # Extra server init flags
     extra_args: list[str] = [*server_args]
-    if lora_available:
-        name = request.getfixturevalue("lora_adapter_name")
-        path = request.getfixturevalue("lora_adapter_path")
+    name = request.getfixturevalue("lora_adapter_name")
+    path = request.getfixturevalue("lora_adapter_path")
 
-        extra_args.extend(("--enable-lora", f"--lora-modules={name}={path}"))
+    extra_args.extend(("--enable-lora", f"--lora-modules={name}={path}"))
 
     if disable_frontend_multiprocessing:
         extra_args.append("--disable-frontend-multiprocessing")

--- a/tests/test_termination_log.py
+++ b/tests/test_termination_log.py
@@ -15,7 +15,6 @@ def termination_log_fpath(tmp_path, monkeypatch):
 @pytest.mark.parametrize(
     "server_args",
     [
-        pytest.param(["--enable-lora"], id="enable-lora"),
         pytest.param(["--max-model-len=10241024"], id="huge-model-len"),
         pytest.param(["--model=google-bert/bert-base-uncased"], id="unsupported-model"),
     ],

--- a/tests/test_termination_log.py
+++ b/tests/test_termination_log.py
@@ -15,17 +15,21 @@ def termination_log_fpath(tmp_path, monkeypatch):
 @pytest.mark.parametrize(
     "server_args",
     [
+        pytest.param(["--enable-lora"], id="enable-lora"),
         pytest.param(["--max-model-len=10241024"], id="huge-model-len"),
         pytest.param(["--model=google-bert/bert-base-uncased"], id="unsupported-model"),
     ],
     indirect=True,
 )
-def test_startup_fails(request, args, termination_log_fpath):
+def test_startup_fails(request, args, termination_log_fpath, lora_available):
     """Test that common set-up errors crash the server on startup.
 
     These errors should be properly reported in the termination log.
 
     """
+    if lora_available and args.enable_lora:
+        pytest.skip("This test requires a non-lora supported device to run")
+
     # Server fixture is called explicitly so that we can handle thrown exception
     with pytest.raises(TaskFailedError):
         _ = request.getfixturevalue("_servers")

--- a/tests/test_termination_log.py
+++ b/tests/test_termination_log.py
@@ -15,21 +15,17 @@ def termination_log_fpath(tmp_path, monkeypatch):
 @pytest.mark.parametrize(
     "server_args",
     [
-        pytest.param(["--enable-lora"], id="enable-lora"),
         pytest.param(["--max-model-len=10241024"], id="huge-model-len"),
         pytest.param(["--model=google-bert/bert-base-uncased"], id="unsupported-model"),
     ],
     indirect=True,
 )
-def test_startup_fails(request, args, termination_log_fpath, lora_available):
+def test_startup_fails(request, args, termination_log_fpath):
     """Test that common set-up errors crash the server on startup.
 
     These errors should be properly reported in the termination log.
 
     """
-    if lora_available and args.enable_lora:
-        pytest.skip("This test requires a non-lora supported device to run")
-
     # Server fixture is called explicitly so that we can handle thrown exception
     with pytest.raises(TaskFailedError):
         _ = request.getfixturevalue("_servers")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -53,20 +53,22 @@ def wait_until(
     start = time.perf_counter()
     exc = None
 
+    attempts = 0
     while (time.perf_counter() - start) < timeout:
+        attempts += 1
         try:
             value = pred()
         except TaskFailedError:
             raise
         except Exception as e:  # noqa: BLE001
-            print(f"Got {e=}")
+            print(f"Attempt {attempts} failed, got {e=}")
             exc = e
         else:
             return value
 
         time.sleep(pause)
 
-    raise TimeoutError("timed out waiting") from exc
+    raise TimeoutError(f"timed out waiting ({timeout=}, {attempts=}) ") from exc
 
 
 def get_server_certificate(host: str, port: int) -> str:


### PR DESCRIPTION
The vllm isolated build for CPU is currently broken resulting in some `torch`-related not being found in the `_C.abi3.so` during testing, breaking CI

This PR addresses this by retrieving the build dependencies beforehand (when `VLLM_VERSION_OVERRIDE` is defined) and pre-installing them, to allow for vllm to be built using `--no-build-isolation`

This only works with local paths and `git+https://github.com/vllm-project/vllm@ref` style overrides (such as those used in CI)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Centralized, idempotent handling for optional vLLM wheel overrides; CI can check out and build specified vLLM refs and provide them as an override.
  - Added a script to install vLLM build dependencies and support building/providing vLLM wheels.
  - Simplified CI matrix/caching and lint setup; added a lint ignore for the new helper script.
- Documentation
  - Updated installation guidance to a from-source vLLM build-and-wheel workflow.
- Tests
  - vLLM override installation invoked consistently before/after deps; test CLI args adjusted and a parameterized test case removed.
  - Increased health-check patience and improved timeout/error reporting in test utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->