### PR TITLE
add support for guided decoding on vllm>=0.10.1

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,7 +37,8 @@ jobs:
         pyv: ["3.12"]
         vllm_ref:
           - "v0.10.0"
-          - "main"
+          - "v0.10.1.1"
+          - "v0.10.2"
 
     steps:
       - name: Check out the repository

--- a/examples/inference.sh
+++ b/examples/inference.sh
@@ -21,7 +21,8 @@ grpcurl -v \
       "stopping": {
         "min_new_tokens": 10,
         "max_new_tokens": 100
-      }
+      },
+      "decoding": {"regex": "\d\.\d+"}
     }
   }' \
 	"${GRPC_HOSTNAME}:${GRPC_PORT}" \

--- a/src/vllm_tgis_adapter/tgis_utils/guided_decoding.py
+++ b/src/vllm_tgis_adapter/tgis_utils/guided_decoding.py
@@ -1,93 +1,10 @@
 from __future__ import annotations
 
-import asyncio
-import concurrent.futures
-from re import escape as regex_escape
-from typing import TYPE_CHECKING
-
-from vllm import __version_tuple__ as vllm_version
-
-if vllm_version <= (0, 10, 0):
-    from vllm.model_executor.guided_decoding import outlines_decoding
-    from vllm.model_executor.guided_decoding.outlines_decoding import (
-        GuidedDecodingMode,
-        _get_logits_processor,
-    )
-else:
-    from vllm.sampling_params import GuidedDecodingParams
+from vllm.sampling_params import GuidedDecodingParams
 
 from vllm_tgis_adapter.grpc.pb.generation_pb2 import DecodingParameters
 
-if TYPE_CHECKING:
-    from vllm.model_executor.guided_decoding.outlines_logits_processors import (
-        JSONLogitsProcessor,
-        RegexLogitsProcessor,
-    )
-    from vllm.transformers_utils.tokenizer import AnyTokenizer
 
-
-async def get_outlines_guided_decoding_logits_processor(
-    decoding_params: DecodingParameters, tokenizer: AnyTokenizer
-) -> JSONLogitsProcessor | RegexLogitsProcessor | None:
-    """Check for guided decoding parameters.
-
-    Check for guided decoding parameters and get the
-    necessary logits processor for the given guide.
-    We cache logit processors by (guide, tokenizer), and on cache hit
-    we make a shallow copy to reuse the same underlying FSM.
-    """
-    guide, mode = _get_guide_and_mode(decoding_params)
-    if not guide:
-        return None
-
-    if outlines_decoding.global_thread_pool is None:
-        outlines_decoding.global_thread_pool = concurrent.futures.ThreadPoolExecutor(
-            max_workers=2
-        )
-    loop = asyncio.get_running_loop()
-
-    return await loop.run_in_executor(
-        outlines_decoding.global_thread_pool,
-        _get_logits_processor,
-        guide,
-        tokenizer,
-        mode,
-        None,  # guided_whitespace_pattern - TBD
-    )
-
-
-# vllm<=0.10.0 (mostly broken)
-def _get_guide_and_mode(
-    decoding_params: DecodingParameters,
-) -> tuple[str, GuidedDecodingMode] | tuple[None, None]:
-    if not (guided := decoding_params.WhichOneof("guided")):
-        return None, None
-
-    if guided == "json_schema":
-        return decoding_params.json_schema, GuidedDecodingMode.JSON
-
-    if guided == "regex":
-        return decoding_params.regex, GuidedDecodingMode.REGEX
-
-    if guided == "choice":
-        choice_list = decoding_params.choice.choices
-        if len(choice_list) < 2:
-            raise ValueError("Must provide at least two choices")
-        # choice just uses regex
-        choices = [regex_escape(str(choice)) for choice in choice_list]
-        choices_regex = "(" + "|".join(choices) + ")"
-        return choices_regex, GuidedDecodingMode.CHOICE
-
-    if guided == "grammar":
-        return decoding_params.grammar, GuidedDecodingMode.GRAMMAR
-
-    if decoding_params.format == DecodingParameters.JSON:
-        return outlines_decoding.JSON_GRAMMAR, GuidedDecodingMode.GRAMMAR
-
-    raise ValueError(f"{guided=}")
-
-
-# vllm>=0.10.1
 def get_guided_decoding_params(
     decoding_params: DecodingParameters,
 ) -> GuidedDecodingParams | None:

--- a/src/vllm_tgis_adapter/tgis_utils/guided_decoding.py
+++ b/src/vllm_tgis_adapter/tgis_utils/guided_decoding.py
@@ -56,7 +56,7 @@ async def get_outlines_guided_decoding_logits_processor(
     )
 
 
-# vllm<=0.10.0
+# vllm<=0.10.0 (mostly broken)
 def _get_guide_and_mode(
     decoding_params: DecodingParameters,
 ) -> tuple[str, GuidedDecodingMode] | tuple[None, None]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,6 +99,7 @@ def args(  # noqa: PLR0913
             f"--grpc-port={grpc_server_port}",
             f"--port={http_server_port}",
             "--max-model-len=512",
+            "--dtype=float32",
             *extra_args,
         ],
     )

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -2,6 +2,7 @@ import asyncio
 from typing import TYPE_CHECKING
 
 import pytest
+from vllm import __version_tuple__ as vllm_version
 
 from vllm_tgis_adapter.grpc.pb.generation_pb2 import DecodingParameters
 
@@ -161,6 +162,10 @@ def test_error_handling(mocker):
     spy.assert_called_once_with(engine_error)
 
 
+@pytest.mark.xfail(
+    vllm_version <= (0, 10, 0),
+    reason="guided decoding broken vllm<=0.10.0",
+)
 @pytest.mark.parametrize(
     "decoding_params",
     [

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -162,10 +162,6 @@ def test_error_handling(mocker):
     spy.assert_called_once_with(engine_error)
 
 
-@pytest.mark.xfail(
-    vllm_version <= (0, 10, 0),
-    reason="guided decoding broken vllm<=0.10.0",
-)
 @pytest.mark.parametrize(
     "decoding_params",
     [
@@ -190,6 +186,10 @@ def test_error_handling(mocker):
         pytest.param(
             DecodingParameters(grammar=simplified_sql_grammar),
             id="guided_decoding_grammar",
+            marks=pytest.mark.xfail(
+                vllm_version <= (0, 10, 0),
+                reason="grammar not supported in v0.10.0",
+            ),
         ),
     ],
 )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -24,6 +24,8 @@ from vllm_tgis_adapter.grpc.pb.generation_pb2_grpc import GenerationServiceStub
 if TYPE_CHECKING:
     from collections.abc import Generator, Sequence
 
+    from google.protobuf.message import Message
+
     from vllm_tgis_adapter.grpc.pb.generation_pb2 import (
         GenerationResponse,
         ModelInfoResponse,
@@ -125,13 +127,14 @@ class GrpcClient:
             request=ModelInfoRequest(model_id=model_id),
         )
 
-    def make_request(
+    def make_request(  # noqa: PLR0913
         self,
         text: str | list[str],
         model_id: str | None = None,
         max_new_tokens: int = 10,
         adapter_id: str | None = None,
         metadata: list[tuple[str, str]] | None = None,
+        params_kwargs: dict[str, Message] | None = None,
     ) -> GenerationResponse | Sequence[GenerationResponse]:
         # assert model_id  # FIXME: is model_id required?
 
@@ -143,6 +146,7 @@ class GrpcClient:
             requests=[GenerationRequest(text=piece) for piece in text],
             params=Parameters(
                 stopping=StoppingCriteria(max_new_tokens=max_new_tokens),
+                **(params_kwargs if params_kwargs is not None else {}),
             ),
             adapter_id=adapter_id,
         )


### PR DESCRIPTION
`vllm>=0.10.1` got rid of `vllm.model_executor.guided_decoding`, breaking guided decoding support.

This PR changes the adapter's behaviour to use `GuidedDecodingParams` to pass the guided decoding parameters to request parameters when queried via grpc. 

This includes tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added guided decoding support (JSON, JSON Schema, regex, choice, grammar) with version-aware behavior.
  - Test client can include extra request parameters when issuing gRPC calls.

- Tests
  - Added comprehensive guided-decoding tests covering multiple formats; test server now runs with float32.

- Documentation
  - Updated inference example to include a decoding block with a regex pattern.

- Chores
  - CI updated to test against pinned vLLM versions (v0.10.0, v0.10.1.1, v0.10.2).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->