### PR TITLE
vllm 0.11.2 compatibility

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,6 +40,7 @@ jobs:
           - "v0.10.1.1"
           - "v0.10.2" # vllm CPU isolated builds are broken from 0.10.0 until 0.10.2, hence the need for a custom build step (see below)
           - "v0.11.0" # starting from v0.11.0, vllm isolated builds work again
+          - "v0.11.2"
 
     steps:
       - name: Check out the repository

--- a/src/vllm_tgis_adapter/__main__.py
+++ b/src/vllm_tgis_adapter/__main__.py
@@ -14,14 +14,18 @@ from vllm.entrypoints.openai.api_server import (
     create_server_socket,
 )
 from vllm.entrypoints.openai.cli_args import make_arg_parser
-from vllm.utils import FlexibleArgumentParser
 
 from vllm_tgis_adapter.tgis_utils.logs import add_logging_wrappers
 
 from .grpc import run_grpc_server
 from .http import build_http_server, run_http_server
 from .logging import DEFAULT_LOGGER_NAME, init_logger
-from .tgis_utils.args import EnvVarArgumentParser, add_tgis_args, postprocess_tgis_args
+from .tgis_utils.args import (
+    EnvVarArgumentParser,
+    FlexibleArgumentParser,
+    add_tgis_args,
+    postprocess_tgis_args,
+)
 from .utils import check_for_failed_tasks, write_termination_log
 
 if TYPE_CHECKING:

--- a/src/vllm_tgis_adapter/__main__.py
+++ b/src/vllm_tgis_adapter/__main__.py
@@ -12,6 +12,7 @@ import vllm
 from vllm.entrypoints.openai.api_server import (
     build_async_engine_client,
     create_server_socket,
+    maybe_register_tokenizer_info_endpoint,
 )
 from vllm.entrypoints.openai.cli_args import make_arg_parser
 
@@ -45,6 +46,7 @@ async def start_servers(args: argparse.Namespace) -> None:
 
     tasks: list[asyncio.Task] = []
     async with build_async_engine_client(args) as engine:
+        maybe_register_tokenizer_info_endpoint(args)
         add_logging_wrappers(engine)
 
         vllm_server = await build_http_server(args, engine)

--- a/src/vllm_tgis_adapter/grpc/grpc_server.py
+++ b/src/vllm_tgis_adapter/grpc/grpc_server.py
@@ -193,7 +193,10 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
         self.health_servicer = health_servicer
 
     async def post_init(self) -> None:
-        self.config = await self.engine.get_model_config()
+        if vllm_version >= (0, 11, 2):
+            self.config = self.engine.vllm_config.model_config
+        else:
+            self.config = await self.engine.get_model_config()
         self.health_servicer.set(
             self.SERVICE_NAME,
             health_pb2.HealthCheckResponse.SERVING,

--- a/src/vllm_tgis_adapter/http.py
+++ b/src/vllm_tgis_adapter/http.py
@@ -22,6 +22,21 @@ TIMEOUT_KEEP_ALIVE = 5  # seconds
 logger = init_logger(__name__)
 
 
+async def set_correlation_id(request: Request, call_next: Callable) -> Response:
+    # If a correlation ID header is set, then use it as the request ID
+    correlation_id = request.headers.get("X-Correlation-ID", None)
+    if correlation_id:
+        # NB: Setting a header here requires using byte arrays and lowercase
+        headers = dict(request.scope["headers"])
+        headers[b"x-request-id"] = correlation_id.encode()
+        request.scope["headers"] = list(headers.items())
+        # Tell the logger that the request ID is the correlation ID for this
+        # request
+        logs.set_correlation_id(correlation_id, correlation_id)
+
+    return await call_next(request)
+
+
 async def build_http_server(
     args: argparse.Namespace,
     engine: AsyncLLMEngine | AsyncEngineClient,
@@ -29,22 +44,11 @@ async def build_http_server(
     # builds the vllm api server so we can pass reference to it
     # within the tgis adapter
 
+    # hack to get the set_correlation_id middleware working on v0.11.2
+    # Trying to register the middleware after `build_app()` has been called
+    # results in `RuntimeError: Cannot add middleware after an application has started`
+    args.middleware.append("vllm_tgis_adapter.http.set_correlation_id")
     app = build_app(args)
-
-    @app.middleware("http")
-    async def set_correlation_id(request: Request, call_next: Callable) -> Response:
-        # If a correlation ID header is set, then use it as the request ID
-        correlation_id = request.headers.get("X-Correlation-ID", None)
-        if correlation_id:
-            # NB: Setting a header here requires using byte arrays and lowercase
-            headers = dict(request.scope["headers"])
-            headers[b"x-request-id"] = correlation_id.encode()
-            request.scope["headers"] = list(headers.items())
-            # Tell the logger that the request ID is the correlation ID for this
-            # request
-            logs.set_correlation_id(correlation_id, correlation_id)
-
-        return await call_next(request)
 
     if hasattr(engine, "get_vllm_config"):
         vllm_config = await engine.get_vllm_config()

--- a/src/vllm_tgis_adapter/tgis_utils/args.py
+++ b/src/vllm_tgis_adapter/tgis_utils/args.py
@@ -3,7 +3,23 @@ from __future__ import annotations
 import argparse
 import os
 
-from vllm.utils import FlexibleArgumentParser, StoreBoolean
+try:
+    from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+    class StoreBoolean(argparse.Action):  # vllm v0.11.1 implementation
+        def __call__(self, parser, namespace, values, option_string=None):  # noqa: ARG002,ANN001
+            if values.lower() == "true":
+                setattr(namespace, self.dest, True)
+            elif values.lower() == "false":
+                setattr(namespace, self.dest, False)
+            else:
+                raise ValueError(
+                    f"Invalid boolean value: {values}. Expected 'true' or 'false'."
+                )
+
+except ImportError:
+    # vllm < 0.11.1
+    from vllm.utils import FlexibleArgumentParser, StoreBoolean
 
 from vllm_tgis_adapter.grpc.validation import MAX_TOP_N_TOKENS
 from vllm_tgis_adapter.logging import init_logger

--- a/src/vllm_tgis_adapter/tgis_utils/scripts.py
+++ b/src/vllm_tgis_adapter/tgis_utils/scripts.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from vllm.utils import FlexibleArgumentParser
-
 from vllm_tgis_adapter.logging import init_logger
 from vllm_tgis_adapter.tgis_utils import hub
+from vllm_tgis_adapter.tgis_utils.args import FlexibleArgumentParser
 
 logger = init_logger(__name__)
 

--- a/src/vllm_tgis_adapter/utils.py
+++ b/src/vllm_tgis_adapter/utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 from collections.abc import Iterable, Sequence
 from typing import Optional
 
@@ -19,6 +20,13 @@ def check_for_failed_tasks(tasks: Iterable[asyncio.Task]) -> Optional[asyncio.Ta
 def write_termination_log(msg: str, file: str = "/dev/termination-log") -> None:
     """Write to the termination logfile."""
     # From https://github.com/IBM/text-generation-inference/blob/9388f02d222c0dab695bea1fb595cacdf08d5467/server/text_generation_server/utils/termination.py#L4
+    if not os.path.exists(file):  # noqa: PTH110
+        from .logging import DEFAULT_LOGGER_NAME, init_logger
+
+        logger = init_logger(DEFAULT_LOGGER_NAME)
+        logger.debug("Not writing to termination log %s since it does not exist", file)
+        return
+
     try:
         with open(file, "w") as termination_file:
             termination_file.write(f"{msg}\n")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,13 +8,13 @@ from typing import TYPE_CHECKING, Annotated, TypeVar
 import pytest
 import requests
 from vllm.entrypoints.openai.cli_args import make_arg_parser
-from vllm.utils import FlexibleArgumentParser
 
 from vllm_tgis_adapter.__main__ import run_and_catch_termination_cause, start_servers
 from vllm_tgis_adapter.grpc.grpc_server import TextGenerationService
 from vllm_tgis_adapter.healthcheck import health_check
 from vllm_tgis_adapter.tgis_utils.args import (
     EnvVarArgumentParser,
+    FlexibleArgumentParser,
     add_tgis_args,
     postprocess_tgis_args,
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,16 +77,17 @@ def args(  # noqa: PLR0913
     extra_args: list[str] = [*server_args]
 
     adapter_cache_dir = tmp_path_factory.mktemp("adapter_cache")
-    name = request.getfixturevalue("lora_adapter_name")
-    path = request.getfixturevalue("lora_adapter_path")
+    if any("lora" in fixture_name for fixture_name in request.fixturenames):
+        name = request.getfixturevalue("lora_adapter_name")
+        path = request.getfixturevalue("lora_adapter_path")
 
-    extra_args.extend(
-        (
-            "--enable-lora",
-            f"--lora-modules={name}={path}",
-            f"--adapter-cache={adapter_cache_dir}",
+        extra_args.extend(
+            (
+                "--enable-lora",
+                f"--lora-modules={name}={path}",
+                f"--adapter-cache={adapter_cache_dir}",
+            )
         )
-    )
 
     if disable_frontend_multiprocessing:
         extra_args.append("--disable-frontend-multiprocessing")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,17 +44,6 @@ def lora_adapter_path(request: pytest.FixtureRequest) -> str:
     return path
 
 
-@pytest.fixture(
-    params=[
-        # pytest.param(True, id="disable-frontend-multiprocessing=True"),
-        pytest.param(False, id="disable-frontend-multiprocessing=False"),
-    ]
-)
-def disable_frontend_multiprocessing(request):
-    """Enable or disable the frontend-multiprocessing feature."""
-    return request.param
-
-
 @pytest.fixture
 def server_args(request: pytest.FixtureRequest):
     return request.param if hasattr(request, "param") else []
@@ -66,7 +55,6 @@ def args(  # noqa: PLR0913
     monkeypatch,
     grpc_server_port: ArgFixture[int],
     http_server_port: ArgFixture[int],
-    disable_frontend_multiprocessing,
     server_args: ArgFixture[list[str]],
     tmp_path_factory,
 ) -> argparse.Namespace:
@@ -88,9 +76,6 @@ def args(  # noqa: PLR0913
                 f"--adapter-cache={adapter_cache_dir}",
             )
         )
-
-    if disable_frontend_multiprocessing:
-        extra_args.append("--disable-frontend-multiprocessing")
 
     monkeypatch.setattr(
         sys,

--- a/tests/test_termination_log.py
+++ b/tests/test_termination_log.py
@@ -7,6 +7,7 @@ from .utils import TaskFailedError
 def termination_log_fpath(tmp_path, monkeypatch):
     # create termination log before server starts
     temp_file = tmp_path / "termination_log.txt"
+    temp_file.touch()
     monkeypatch.setenv("TERMINATION_LOG_DIR", str(temp_file))
     yield temp_file
     temp_file.unlink(missing_ok=True)

--- a/tests/test_tgis_utils.py
+++ b/tests/test_tgis_utils.py
@@ -1,10 +1,11 @@
 import sys
 
 import pytest
-from vllm.utils import FlexibleArgumentParser, StoreBoolean
 
 from vllm_tgis_adapter.tgis_utils.args import (
     EnvVarArgumentParser,
+    FlexibleArgumentParser,
+    StoreBoolean,
     _bool_from_string,
 )
 


### PR DESCRIPTION
- add maybe_register_tokenizer_info_endpoint (available since vllm>=0.10.0)
- silence write_termination_log exceptions when not required
- handle cli args location change in vllm==0.11.2
- fix http/grpc server startup on vllm>=0.11.2
    - http server: cleanup correlation id middleware definition

tests:
- gha: add v0.11.2 to test matrix
- get rid of disable-frontend-multiprocessing
- only enable lora for lora tests