### PR TITLE
Relax grpcio constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
   "setuptools>=48",
   "setuptools_scm[toml]>=6.3.1",
   # protobuf-generation tools
-  "grpcio-tools==1.62.1",
+  "grpcio-tools>=1.62.1",
   "mypy-protobuf==3.6.0",
   "types-protobuf>=3.20.4"
 ]


### PR DESCRIPTION
We need to relax grpcio-tools constraints to fix a high cve in protobuf.

## Description
Trying to fix a high cve in protobuf 5.29.5 which is resolved in 5.29.6 for the 3.2.2 rebuild. But trying to get around a dependency conflict.

Here’s the situation,
grpcio-reflection==1.70.0 and grpcio-health-checking==1.70.0 require protobuf<6.0dev,>=5.26.1vllm-tgis-adapter==0.9.0.post1 has a build-system dependency on grpcio-tools==1.62.1grpcio-tools==1.62.1 requires protobuf<5.0dev,>=4.21.6

So I can’t pin protobuf >= 5.26.6 in wheel pipeline as it conflicts with grpcio-tools==1.62.1 requirements.
I can’t also update grpcio-tools as it is a strict constraint in vllm-tgis-adapter==0.9.0.post1.

I guess one thing we can do is relax the constraints in vllm-tgis-adapter and issue a new tag for it


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
